### PR TITLE
feat(video): add AI tag suggestions with Groq

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file_path=$(jq -r '.tool_input.file_path // .tool_input.notebook_path' < /dev/stdin) && npx prettier --write \"$file_path\" 2>/dev/null || true",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ next-env.d.ts
 # claude
 .claude/tasks/*
 .claude/docs/*
+.claude/ideas/*
 
 # testing
 /test-results/

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "next": "15.4.4",
     "next-safe-action": "^8.0.8",
     "next-themes": "^0.4.6",
+    "openai": "^6.34.0",
     "react": "19.1.0",
     "react-day-picker": "^9.8.1",
     "react-dom": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      openai:
+        specifier: ^6.34.0
+        version: 6.34.0(ws@8.18.3)(zod@4.0.10)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -4439,6 +4442,18 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  openai@6.34.0:
+    resolution: {integrity: sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -10473,6 +10488,11 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  openai@6.34.0(ws@8.18.3)(zod@4.0.10):
+    optionalDependencies:
+      ws: 8.18.3
+      zod: 4.0.10
 
   optionator@0.9.4:
     dependencies:

--- a/src/components/features/video/note-form.tsx
+++ b/src/components/features/video/note-form.tsx
@@ -21,7 +21,7 @@ import { useSpeechRecognition } from "@/hooks/use-speech-recognition";
 import { cn } from "@/lib/utils";
 import { useVideoPlayerStore } from "@/stores/video-player";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Mic, MicOff } from "lucide-react";
+import { Loader2, Mic, MicOff, Sparkles } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -29,6 +29,7 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { createNoteAction } from "./note-action";
 import { noteSchema, NoteSchemaType } from "./note-schema";
+import { suggestTagsAction } from "./suggest-tags-action";
 
 type NoteFormProps = {
   matchId: string;
@@ -38,6 +39,7 @@ type NoteFormProps = {
 export function NoteForm({ matchId, availableTags }: NoteFormProps) {
   const router = useRouter();
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
+  const [suggestedTagIds, setSuggestedTagIds] = useState<string[]>([]);
 
   const {
     transcript,
@@ -54,10 +56,24 @@ export function NoteForm({ matchId, availableTags }: NoteFormProps) {
     onSuccess: () => {
       form.reset();
       setSelectedTagIds([]);
+      setSuggestedTagIds([]);
       resetTranscript();
       router.refresh();
     },
   });
+
+  const { execute: executeSuggest, isPending: isSuggesting } = useAction(
+    suggestTagsAction,
+    {
+      onSuccess: ({ data }) => {
+        if (!data?.suggestedTags) return;
+        const ids = availableTags
+          .filter((tag) => data.suggestedTags.includes(tag.name))
+          .map((tag) => tag.id);
+        setSuggestedTagIds(ids);
+      },
+    },
+  );
 
   const currentTime = useVideoPlayerStore((state) => state.currentTime);
 
@@ -68,6 +84,8 @@ export function NoteForm({ matchId, availableTags }: NoteFormProps) {
       tagIds: [],
     },
   });
+
+  const noteValue = form.watch("note");
 
   useEffect(() => {
     if (transcript) {
@@ -106,6 +124,25 @@ export function NoteForm({ matchId, availableTags }: NoteFormProps) {
       form.setValue("tagIds", newTagIds);
       return newTagIds;
     });
+  };
+
+  const handleSuggestTags = () => {
+    const noteText = form.getValues("note");
+    if (noteText.length < 10) return;
+    executeSuggest({
+      noteText,
+      availableTagNames: availableTags.map((t) => t.name),
+    });
+  };
+
+  const handleAcceptAllSuggestions = () => {
+    const unselected = suggestedTagIds.filter(
+      (id) => !selectedTagIds.includes(id),
+    );
+    const newTagIds = [...selectedTagIds, ...unselected].slice(0, 10);
+    setSelectedTagIds(newTagIds);
+    form.setValue("tagIds", newTagIds);
+    setSuggestedTagIds([]);
   };
 
   const onSubmit = (data: NoteSchemaType) => {
@@ -181,29 +218,83 @@ export function NoteForm({ matchId, availableTags }: NoteFormProps) {
         />
 
         <div className="space-y-3">
-          <FormLabel>Tags ({selectedTagIds.length}/10)</FormLabel>
+          <div className="flex items-center justify-between">
+            <FormLabel>Tags ({selectedTagIds.length}/10)</FormLabel>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSuggestTags}
+                    disabled={isSuggesting || noteValue.length < 10}
+                  >
+                    {isSuggesting ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Sparkles className="h-4 w-4" />
+                    )}
+                    {isSuggesting
+                      ? "Suggestion en cours..."
+                      : "Suggérer des tags"}
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {noteValue.length < 10 && (
+                <TooltipContent>
+                  La note doit contenir au moins 10 caractères
+                </TooltipContent>
+              )}
+            </Tooltip>
+          </div>
           <FormDescription>
             Sélectionnez les tags qui décrivent cette note
           </FormDescription>
+          {suggestedTagIds.length > 0 && (
+            <div className="flex items-center gap-2">
+              <p className="text-muted-foreground text-xs">
+                Tags suggérés par l&apos;IA
+              </p>
+              <button
+                type="button"
+                onClick={handleAcceptAllSuggestions}
+                className="text-primary text-xs underline"
+              >
+                Tout accepter
+              </button>
+            </div>
+          )}
           <div className="flex flex-wrap gap-2">
             {availableTags.map((tag) => {
               const isSelected = selectedTagIds.includes(tag.id);
-              const isDisabled = !isSelected && selectedTagIds.length >= 10;
+              const isSuggested =
+                !isSelected && suggestedTagIds.includes(tag.id);
+              const isDisabled =
+                !isSelected && !isSuggested && selectedTagIds.length >= 10;
 
               return (
                 <button
                   key={tag.id}
                   type="button"
-                  onClick={() => toggleTag(tag.id)}
+                  onClick={() => {
+                    toggleTag(tag.id);
+                    setSuggestedTagIds((prev) =>
+                      prev.filter((id) => id !== tag.id),
+                    );
+                  }}
                   disabled={isDisabled}
                   className={cn(
                     "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
                     isSelected
                       ? "bg-primary text-primary-foreground"
-                      : "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+                      : isSuggested
+                        ? "bg-secondary text-secondary-foreground ring-primary/50 ring-2"
+                        : "bg-secondary text-secondary-foreground hover:bg-secondary/80",
                     isDisabled && "cursor-not-allowed opacity-50",
                   )}
                 >
+                  {isSuggested && <Sparkles className="mr-1 inline h-3 w-3" />}
                   {tag.name}
                 </button>
               );

--- a/src/components/features/video/suggest-tags-action.ts
+++ b/src/components/features/video/suggest-tags-action.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { suggestTagsFromNote } from "@/lib/ai/groq";
+import { actionClient } from "@/lib/safe-action";
+import z from "zod";
+
+export const suggestTagsAction = actionClient
+  .inputSchema(
+    z.object({
+      noteText: z.string().min(10, {
+        error: "La note doit contenir au moins 10 caractères",
+      }),
+      availableTagNames: z
+        .array(z.string())
+        .min(1, { error: "Au moins un tag disponible requis" }),
+    }),
+  )
+  .action(async ({ parsedInput }) => {
+    const { noteText, availableTagNames } = parsedInput;
+
+    const suggestedTags = await suggestTagsFromNote(
+      noteText,
+      availableTagNames,
+    );
+
+    return { suggestedTags };
+  });

--- a/src/lib/ai/groq.ts
+++ b/src/lib/ai/groq.ts
@@ -1,0 +1,51 @@
+import { env } from "@/lib/env";
+import OpenAI from "openai";
+
+const groqClient = env.GROQ_API_KEY
+  ? new OpenAI({
+      apiKey: env.GROQ_API_KEY,
+      baseURL: "https://api.groq.com/openai/v1",
+    })
+  : null;
+
+export async function suggestTagsFromNote(
+  noteText: string,
+  availableTagNames: string[],
+): Promise<string[]> {
+  if (!groqClient) {
+    return [];
+  }
+
+  try {
+    const response = await groqClient.chat.completions.create({
+      model: "llama-3.1-8b-instant",
+      messages: [
+        {
+          role: "system",
+          content: `You are a fighting game tagging assistant. Given a note about a fighting game match, suggest 1 to 3 tags from the provided list that best describe the note. Reply with valid JSON only in the format: {"tags": ["Tag1", "Tag2"]}. Only use tags from the provided list. Never invent new tags.`,
+        },
+        {
+          role: "user",
+          content: `Available tags: ${availableTagNames.join(", ")}\n\nNote: "${noteText}"`,
+        },
+      ],
+      response_format: { type: "json_object" },
+      temperature: 0.2,
+      max_tokens: 100,
+    });
+
+    const content = response.choices[0]?.message?.content;
+    if (!content) {
+      return [];
+    }
+
+    const parsed = JSON.parse(content) as { tags?: string[] };
+    if (!Array.isArray(parsed.tags)) {
+      return [];
+    }
+
+    return parsed.tags.filter((tag) => availableTagNames.includes(tag));
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,6 +5,7 @@ export const env = createEnv({
   server: {
     DATABASE_URL: z.url(),
     OPEN_AI_API_KEY: z.string().min(1).optional(),
+    GROQ_API_KEY: z.string().min(1).optional(),
     GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
     AWS_S3_BUCKET_NAME: z.string().min(1),
     AWS_S3_API_URL: z.string().url(),


### PR DESCRIPTION
## Summary

• Add AI-powered tag suggestions using Groq API (Llama 3.1 8B, free tier)
• New "Suggérer des tags" button in note form with Sparkles icon
• Suggested tags highlighted with ring border, "Tout accepter" shortcut
• Graceful degradation: returns empty when GROQ_API_KEY is missing or API fails
• Tooltip on disabled button explaining minimum note length (10 chars)

## Type

feat

## Setup

Add `GROQ_API_KEY` to `.env.local` (free key from https://console.groq.com)