### PR TITLE
feat(video): add smart note templates

### DIFF
--- a/src/components/features/video/note-form.tsx
+++ b/src/components/features/video/note-form.tsx
@@ -12,16 +12,9 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useSpeechRecognition } from "@/hooks/use-speech-recognition";
-import { cn } from "@/lib/utils";
 import { useVideoPlayerStore } from "@/stores/video-player";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Loader2, Mic, MicOff, Sparkles } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -29,6 +22,11 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { createNoteAction } from "./note-action";
 import { noteSchema, NoteSchemaType } from "./note-schema";
+import { NoteSuggestTagsButton } from "./note-suggest-tags-button";
+import { NoteTagButton } from "./note-tag-button";
+import { NoteTemplateSelector } from "./note-template-selector";
+import { NoteTemplate } from "./note-templates";
+import { NoteVoiceRecorder } from "./note-voice-recorder";
 import { suggestTagsAction } from "./suggest-tags-action";
 
 type NoteFormProps = {
@@ -113,6 +111,13 @@ export function NoteForm({ matchId, availableTags }: NoteFormProps) {
     }
   };
 
+  const handleSelectTemplate = (template: NoteTemplate) => {
+    form.setValue("note", template.content, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+  };
+
   const toggleTag = (tagId: string) => {
     setSelectedTagIds((prev) => {
       const newTagIds = prev.includes(tagId)
@@ -164,38 +169,15 @@ export function NoteForm({ matchId, availableTags }: NoteFormProps) {
             <FormItem>
               <div className="flex items-center justify-between">
                 <FormLabel>Note</FormLabel>
-                {isSupported && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        onClick={handleToggleRecording}
-                        className={cn(
-                          "h-8 w-8",
-                          isListening && "text-destructive animate-pulse",
-                        )}
-                        aria-label={
-                          isListening
-                            ? "Arrêter la dictée vocale"
-                            : "Démarrer la dictée vocale"
-                        }
-                      >
-                        {isListening ? (
-                          <MicOff className="h-4 w-4" />
-                        ) : (
-                          <Mic className="h-4 w-4" />
-                        )}
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {isListening
-                        ? "Arrêter la dictée vocale"
-                        : "Dicter une note"}
-                    </TooltipContent>
-                  </Tooltip>
-                )}
+                <div className="flex items-center gap-1">
+                  <NoteTemplateSelector onSelect={handleSelectTemplate} />
+                  {isSupported && (
+                    <NoteVoiceRecorder
+                      isListening={isListening}
+                      onToggle={handleToggleRecording}
+                    />
+                  )}
+                </div>
               </div>
               <FormControl>
                 <Textarea
@@ -220,33 +202,11 @@ export function NoteForm({ matchId, availableTags }: NoteFormProps) {
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <FormLabel>Tags ({selectedTagIds.length}/10)</FormLabel>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={handleSuggestTags}
-                    disabled={isSuggesting || noteValue.length < 10}
-                  >
-                    {isSuggesting ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Sparkles className="h-4 w-4" />
-                    )}
-                    {isSuggesting
-                      ? "Suggestion en cours..."
-                      : "Suggérer des tags"}
-                  </Button>
-                </span>
-              </TooltipTrigger>
-              {noteValue.length < 10 && (
-                <TooltipContent>
-                  La note doit contenir au moins 10 caractères
-                </TooltipContent>
-              )}
-            </Tooltip>
+            <NoteSuggestTagsButton
+              onSuggest={handleSuggestTags}
+              isSuggesting={isSuggesting}
+              disabled={noteValue.length < 10}
+            />
           </div>
           <FormDescription>
             Sélectionnez les tags qui décrivent cette note
@@ -274,29 +234,19 @@ export function NoteForm({ matchId, availableTags }: NoteFormProps) {
                 !isSelected && !isSuggested && selectedTagIds.length >= 10;
 
               return (
-                <button
+                <NoteTagButton
                   key={tag.id}
-                  type="button"
+                  tag={tag}
+                  isSelected={isSelected}
+                  isSuggested={isSuggested}
+                  isDisabled={isDisabled}
                   onClick={() => {
                     toggleTag(tag.id);
                     setSuggestedTagIds((prev) =>
                       prev.filter((id) => id !== tag.id),
                     );
                   }}
-                  disabled={isDisabled}
-                  className={cn(
-                    "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
-                    isSelected
-                      ? "bg-primary text-primary-foreground"
-                      : isSuggested
-                        ? "bg-secondary text-secondary-foreground ring-primary/50 ring-2"
-                        : "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-                    isDisabled && "cursor-not-allowed opacity-50",
-                  )}
-                >
-                  {isSuggested && <Sparkles className="mr-1 inline h-3 w-3" />}
-                  {tag.name}
-                </button>
+                />
               );
             })}
           </div>

--- a/src/components/features/video/note-suggest-tags-button.tsx
+++ b/src/components/features/video/note-suggest-tags-button.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Loader2, Sparkles } from "lucide-react";
+
+type NoteSuggestTagsButtonProps = {
+  onSuggest: () => void;
+  isSuggesting: boolean;
+  disabled: boolean;
+};
+
+export function NoteSuggestTagsButton({
+  onSuggest,
+  isSuggesting,
+  disabled,
+}: NoteSuggestTagsButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onSuggest}
+            disabled={isSuggesting || disabled}
+          >
+            {isSuggesting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Sparkles className="h-4 w-4" />
+            )}
+            {isSuggesting ? "Suggestion en cours..." : "Suggérer des tags"}
+          </Button>
+        </span>
+      </TooltipTrigger>
+      {disabled && (
+        <TooltipContent>
+          La note doit contenir au moins 10 caractères
+        </TooltipContent>
+      )}
+    </Tooltip>
+  );
+}

--- a/src/components/features/video/note-tag-button.tsx
+++ b/src/components/features/video/note-tag-button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Tag } from "@/../generated/prisma";
+import { cn } from "@/lib/utils";
+import { Sparkles } from "lucide-react";
+
+type NoteTagButtonProps = {
+  tag: Tag;
+  isSelected: boolean;
+  isSuggested: boolean;
+  isDisabled: boolean;
+  onClick: () => void;
+};
+
+export function NoteTagButton({
+  tag,
+  isSelected,
+  isSuggested,
+  isDisabled,
+  onClick,
+}: NoteTagButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isDisabled}
+      className={cn(
+        "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+        isSelected
+          ? "bg-primary text-primary-foreground"
+          : isSuggested
+            ? "bg-secondary text-secondary-foreground ring-primary/50 ring-2"
+            : "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        isDisabled && "cursor-not-allowed opacity-50",
+      )}
+    >
+      {isSuggested && <Sparkles className="mr-1 inline h-3 w-3" />}
+      {tag.name}
+    </button>
+  );
+}

--- a/src/components/features/video/note-template-selector.tsx
+++ b/src/components/features/video/note-template-selector.tsx
@@ -21,6 +21,18 @@ import {
   NoteTemplate,
 } from "./note-templates";
 
+const CATEGORY_COLORS: Record<
+  (typeof NOTE_TEMPLATE_CATEGORIES)[number],
+  string
+> = {
+  Offense: "bg-red-500/15 text-red-700 dark:text-red-400",
+  Defense: "bg-blue-500/15 text-blue-700 dark:text-blue-400",
+  Neutral: "bg-green-500/15 text-green-700 dark:text-green-400",
+  Mental: "bg-purple-500/15 text-purple-700 dark:text-purple-400",
+  Execution: "bg-orange-500/15 text-orange-700 dark:text-orange-400",
+  Okizeme: "bg-yellow-500/15 text-yellow-700 dark:text-yellow-400",
+};
+
 type NoteTemplateSelectorProps = {
   onSelect: (template: NoteTemplate) => void;
 };
@@ -44,14 +56,15 @@ export function NoteTemplateSelector({ onSelect }: NoteTemplateSelectorProps) {
         </TooltipTrigger>
         <TooltipContent>Utiliser un modèle de note</TooltipContent>
       </Tooltip>
-      <DropdownMenuContent
-        align="end"
-        className="max-h-80 overflow-y-auto"
-      >
+      <DropdownMenuContent align="end" className="max-h-80 overflow-y-auto">
         {NOTE_TEMPLATE_CATEGORIES.map((category, index) => (
           <div key={category}>
             {index > 0 && <DropdownMenuSeparator />}
-            <DropdownMenuLabel>{category}</DropdownMenuLabel>
+            <DropdownMenuLabel
+              className={`mx-1 rounded-sm px-2 ${CATEGORY_COLORS[category]}`}
+            >
+              {category}
+            </DropdownMenuLabel>
             {NOTE_TEMPLATES.filter((t) => t.category === category).map(
               (template) => (
                 <DropdownMenuItem

--- a/src/components/features/video/note-template-selector.tsx
+++ b/src/components/features/video/note-template-selector.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ClipboardList } from "lucide-react";
+import {
+  NOTE_TEMPLATE_CATEGORIES,
+  NOTE_TEMPLATES,
+  NoteTemplate,
+} from "./note-templates";
+
+type NoteTemplateSelectorProps = {
+  onSelect: (template: NoteTemplate) => void;
+};
+
+export function NoteTemplateSelector({ onSelect }: NoteTemplateSelectorProps) {
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              aria-label="Utiliser un modèle de note"
+            >
+              <ClipboardList className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Utiliser un modèle de note</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        align="end"
+        className="max-h-80 overflow-y-auto"
+      >
+        {NOTE_TEMPLATE_CATEGORIES.map((category, index) => (
+          <div key={category}>
+            {index > 0 && <DropdownMenuSeparator />}
+            <DropdownMenuLabel>{category}</DropdownMenuLabel>
+            {NOTE_TEMPLATES.filter((t) => t.category === category).map(
+              (template) => (
+                <DropdownMenuItem
+                  key={template.id}
+                  onClick={() => onSelect(template)}
+                >
+                  {template.name}
+                </DropdownMenuItem>
+              ),
+            )}
+          </div>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/features/video/note-templates.ts
+++ b/src/components/features/video/note-templates.ts
@@ -1,0 +1,176 @@
+export type NoteTemplate = {
+  id: string;
+  name: string;
+  content: string;
+  category: string;
+};
+
+export const NOTE_TEMPLATE_CATEGORIES = [
+  "Offense",
+  "Defense",
+  "Neutral",
+  "Mental",
+  "Execution",
+  "Okizeme",
+] as const;
+
+export const NOTE_TEMPLATES: NoteTemplate[] = [
+  // Offense
+  {
+    id: "dropped-combo",
+    name: "Dropped Combo",
+    content:
+      "Dropped combo. Need to practice [specific input] execution.",
+    category: "Offense",
+  },
+  {
+    id: "missed-punish",
+    name: "Missed Punish",
+    content:
+      "Opponent was minus/unsafe. Should have punished with [move].",
+    category: "Offense",
+  },
+  {
+    id: "reset-opportunity",
+    name: "Reset Opportunity",
+    content:
+      "Had reset potential here. Could have extended pressure instead of letting them recover.",
+    category: "Offense",
+  },
+  {
+    id: "frame-trap-failed",
+    name: "Frame Trap Failed",
+    content:
+      "Frame trap gap too big. Need tighter sequencing with [move A] into [move B].",
+    category: "Offense",
+  },
+  {
+    id: "whiff-punish",
+    name: "Whiff Punish",
+    content:
+      "Opponent whiffed [move]. Should have punished from this range.",
+    category: "Offense",
+  },
+
+  // Defense
+  {
+    id: "failed-anti-air",
+    name: "Failed Anti-Air",
+    content:
+      "Got jumped in on. Didn't anti-air in time or picked wrong option.",
+    category: "Defense",
+  },
+  {
+    id: "bad-wakeup",
+    name: "Bad Wakeup Choice",
+    content:
+      "Wakeup reversal got baited. Should block on wakeup most of the time.",
+    category: "Defense",
+  },
+  {
+    id: "throw-tech-missed",
+    name: "Throw Tech Missed",
+    content:
+      "Got thrown. Need to stay alert and tech during pressure.",
+    category: "Defense",
+  },
+  {
+    id: "wrong-block",
+    name: "Wrong Block",
+    content:
+      "Got hit low/overhead. Need to adjust blocking during mixup strings.",
+    category: "Defense",
+  },
+  {
+    id: "got-crossed-up",
+    name: "Got Crossed Up",
+    content:
+      "Didn't adjust block direction on crossup fast enough.",
+    category: "Defense",
+  },
+
+  // Neutral
+  {
+    id: "spacing-control-lost",
+    name: "Spacing Control Lost",
+    content:
+      "Got pushed into corner too easily. Need better footsies to control space.",
+    category: "Neutral",
+  },
+  {
+    id: "footsies-read",
+    name: "Footsies Read",
+    content:
+      "Good read on opponent's poke pattern. Capitalize on this spacing next time.",
+    category: "Neutral",
+  },
+  {
+    id: "backdash-timing",
+    name: "Backdash Timing",
+    content:
+      "Backdash too slow to escape pressure. Either backdash earlier or find safer option.",
+    category: "Neutral",
+  },
+
+  // Mental
+  {
+    id: "downloaded-opponent",
+    name: "Downloaded Opponent",
+    content:
+      "Opponent keeps using [pattern]. Counter with [strategy] next time.",
+    category: "Mental",
+  },
+  {
+    id: "need-to-adapt",
+    name: "Need to Adapt",
+    content:
+      "They figured out my [strategy]. Have to mix up approach.",
+    category: "Mental",
+  },
+  {
+    id: "good-adaptation",
+    name: "Good Adaptation",
+    content:
+      "Adjusted to opponent's [habit] and it worked. Keep this read.",
+    category: "Mental",
+  },
+
+  // Execution
+  {
+    id: "input-error",
+    name: "Input Error",
+    content:
+      "Special move didn't come out. Likely dropped the motion input.",
+    category: "Execution",
+  },
+  {
+    id: "timing-issue",
+    name: "Timing Issue",
+    content:
+      "Link wasn't tight enough. [Move A] to [Move B] needs more practice.",
+    category: "Execution",
+  },
+  {
+    id: "combo-route-choice",
+    name: "Combo Route Choice",
+    content:
+      "Used suboptimal combo route. Better option available for more damage/oki.",
+    category: "Execution",
+  },
+
+  // Okizeme
+  {
+    id: "oki-setup-missed",
+    name: "Oki Setup Missed",
+    content:
+      "Got knockdown but wasted the advantage. Should have done [oki option].",
+    category: "Okizeme",
+  },
+  {
+    id: "pressure-gap",
+    name: "Pressure Gap",
+    content:
+      "Left a gap in pressure. Opponent mashed out. Tighten up blockstring.",
+    category: "Okizeme",
+  },
+];

--- a/src/components/features/video/note-voice-recorder.tsx
+++ b/src/components/features/video/note-voice-recorder.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { Mic, MicOff } from "lucide-react";
+
+type NoteVoiceRecorderProps = {
+  isListening: boolean;
+  onToggle: () => void;
+};
+
+export function NoteVoiceRecorder({
+  isListening,
+  onToggle,
+}: NoteVoiceRecorderProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onToggle}
+          className={cn(
+            "h-8 w-8",
+            isListening && "text-destructive animate-pulse",
+          )}
+          aria-label={
+            isListening
+              ? "Arrêter la dictée vocale"
+              : "Démarrer la dictée vocale"
+          }
+        >
+          {isListening ? (
+            <MicOff className="h-4 w-4" />
+          ) : (
+            <Mic className="h-4 w-4" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        {isListening ? "Arrêter la dictée vocale" : "Dicter une note"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## Summary

• Add 21 FGC note templates across 6 categories (Offense, Defense, Neutral, Mental, Execution, Okizeme) for quick note pre-filling
• Color-coded category labels in the template dropdown for easy visual distinction
• Extract note form UI into focused components: template selector, voice recorder, tag button, suggest tags button
• Refactor `note-form.tsx` from monolithic to composable architecture for better readability

## Type

feat