### PR TITLE
feat(strategy-matrix): implement V1 with interactive decision grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-04-26
+
+### Added: Strategy Matrix V1 (matrice État × Action standalone)
+
+### Changed: Dashboard CTA "Nouvelle note personnelle" redirige vers la création de matrice de stratégie
+
 ## 2026-04-20
 
 ### Added: Prisma models Game, Character, Combo (phase 1)

--- a/app/(dashboard)/notes/strategy/[id]/page.tsx
+++ b/app/(dashboard)/notes/strategy/[id]/page.tsx
@@ -1,0 +1,43 @@
+import { StrategyMatrixForm } from "@/components/features/strategy-matrix/strategy-matrix-form";
+import { StrategyMatrixHelpDialog } from "@/components/features/strategy-matrix/strategy-matrix-help-dialog";
+import { requireAuth } from "@/lib/auth-utils";
+import { notFound } from "next/navigation";
+import { getStrategyMatrixById } from "../../../../../prisma/query/strategy-matrix.query";
+
+export default async function StrategyMatrixDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const user = await requireAuth();
+  const matrix = await getStrategyMatrixById({ id, userId: user.id });
+
+  if (!matrix) notFound();
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 px-4 py-8">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold">{matrix.title}</h1>
+          {matrix.description && (
+            <p className="text-muted-foreground mt-1">{matrix.description}</p>
+          )}
+        </div>
+        <StrategyMatrixHelpDialog />
+      </div>
+
+      <StrategyMatrixForm
+        mode="edit"
+        matrixId={matrix.id}
+        initialData={{
+          title: matrix.title,
+          description: matrix.description ?? undefined,
+          myAxis: matrix.myAxis,
+          opponentAxis: matrix.opponentAxis,
+          cells: matrix.cells,
+        }}
+      />
+    </div>
+  );
+}

--- a/app/(dashboard)/notes/strategy/new/page.tsx
+++ b/app/(dashboard)/notes/strategy/new/page.tsx
@@ -1,0 +1,24 @@
+import { StrategyMatrixForm } from "@/components/features/strategy-matrix/strategy-matrix-form";
+import { StrategyMatrixHelpDialog } from "@/components/features/strategy-matrix/strategy-matrix-help-dialog";
+import { requireAuth } from "@/lib/auth-utils";
+
+export default async function NewStrategyMatrixPage() {
+  await requireAuth();
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 px-4 py-8">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold">Nouvelle matrice de stratégie</h1>
+          <p className="text-muted-foreground mt-1">
+            Définissez vos axes (mes ressources × ressources adverses) et
+            remplissez chaque cellule avec votre stratégie.
+          </p>
+        </div>
+        <StrategyMatrixHelpDialog />
+      </div>
+
+      <StrategyMatrixForm mode="create" />
+    </div>
+  );
+}

--- a/app/(dashboard)/notes/strategy/page.tsx
+++ b/app/(dashboard)/notes/strategy/page.tsx
@@ -1,0 +1,32 @@
+import { StrategyMatrixList } from "@/components/features/strategy-matrix/strategy-matrix-list";
+import { Button } from "@/components/ui/button";
+import { requireAuth } from "@/lib/auth-utils";
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import { getStrategyMatrices } from "../../../../prisma/query/strategy-matrix.query";
+
+export default async function StrategyMatrixListPage() {
+  const user = await requireAuth();
+  const matrices = await getStrategyMatrices({ userId: user.id });
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 px-4 py-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Matrices de stratégie</h1>
+          <p className="text-muted-foreground mt-1">
+            Vos plans de jeu conditionnels par état des ressources.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/notes/strategy/new">
+            <Plus className="mr-2 h-4 w-4" />
+            Nouvelle matrice
+          </Link>
+        </Button>
+      </div>
+
+      <StrategyMatrixList matrices={matrices} />
+    </div>
+  );
+}

--- a/prisma/migrations/20260426152012_add_strategy_matrix/migration.sql
+++ b/prisma/migrations/20260426152012_add_strategy_matrix/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "StrategyMatrix" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "myAxis" JSONB NOT NULL,
+    "opponentAxis" JSONB NOT NULL,
+    "cells" JSONB NOT NULL,
+    "pinned" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StrategyMatrix_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "StrategyMatrix_userId_idx" ON "StrategyMatrix"("userId");
+
+-- AddForeignKey
+ALTER TABLE "StrategyMatrix" ADD CONSTRAINT "StrategyMatrix_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/query/strategy-matrix.query.ts
+++ b/prisma/query/strategy-matrix.query.ts
@@ -1,0 +1,67 @@
+import {
+  axisSchema,
+  cellSchema,
+  type Axis,
+  type Cell,
+} from "@/components/features/strategy-matrix/strategy-matrix-schema";
+import { prisma } from "@/lib/prisma";
+import z from "zod";
+import { Prisma } from "../../generated/prisma";
+
+export const getStrategyMatrices = async ({ userId }: { userId: string }) =>
+  await prisma.strategyMatrix.findMany({
+    where: { userId },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      myAxis: true,
+      opponentAxis: true,
+      pinned: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    orderBy: [{ pinned: "desc" }, { updatedAt: "desc" }],
+  });
+
+export type StrategyMatrixListItem = Prisma.PromiseReturnType<
+  typeof getStrategyMatrices
+>[number];
+
+export const getStrategyMatrixById = async ({
+  id,
+  userId,
+}: {
+  id: string;
+  userId: string;
+}) => {
+  const matrix = await prisma.strategyMatrix.findFirst({
+    where: { id, userId },
+  });
+
+  if (!matrix) return null;
+
+  const myAxis = axisSchema.parse(matrix.myAxis);
+  const opponentAxis = axisSchema.parse(matrix.opponentAxis);
+  const cells = z.array(cellSchema).parse(matrix.cells);
+
+  return {
+    id: matrix.id,
+    userId: matrix.userId,
+    title: matrix.title,
+    description: matrix.description,
+    pinned: matrix.pinned,
+    createdAt: matrix.createdAt,
+    updatedAt: matrix.updatedAt,
+    myAxis,
+    opponentAxis,
+    cells,
+  };
+};
+
+export type StrategyMatrixDetail = NonNullable<
+  Awaited<ReturnType<typeof getStrategyMatrixById>>
+>;
+
+export type StrategyMatrixListAxis = Axis;
+export type StrategyMatrixListCell = Cell;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   role             UserRole           @default(USER)
   glossaryArticles GlossaryArticle[]  @relation("GlossaryArticles")
   combos           Combo[]
+  strategyMatrices StrategyMatrix[]
 
   @@map("user")
 }
@@ -153,6 +154,22 @@ model Combo {
   @@index([userId])
   @@index([characterId])
   @@index([gameId])
+}
+
+model StrategyMatrix {
+  id           String   @id @default(cuid())
+  userId       String
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  title        String
+  description  String?
+  myAxis       Json
+  opponentAxis Json
+  cells        Json
+  pinned       Boolean  @default(false)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@index([userId])
 }
 
 model GlossaryArticle {

--- a/src/components/features/dashboard/cta-section.tsx
+++ b/src/components/features/dashboard/cta-section.tsx
@@ -23,15 +23,16 @@ export function CTASection() {
         <span className="text-foreground font-medium">Get good, faster.</span>
       </p>
       <div className="flex justify-center gap-4">
-        <Button
-          className="rounded-full font-semibold backdrop-blur transition-all hover:scale-105 hover:bg-zinc-200"
-          variant="secondary"
-          size="lg"
-          onClick={() => {}}
-        >
-          <Plus className="mr-2 h-4 w-4" />
-          Nouvelle note personnelle
-        </Button>
+        <Link href="/notes/strategy/new">
+          <Button
+            className="rounded-full font-semibold backdrop-blur transition-all hover:scale-105 hover:bg-zinc-200"
+            variant="secondary"
+            size="lg"
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            Nouvelle matrice de stratégie
+          </Button>
+        </Link>
         <Link href="/videos/new">
           <Button
             className="rounded-full font-semibold backdrop-blur transition-all hover:scale-105"

--- a/src/components/features/strategy-matrix/strategy-matrix-action.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-action.ts
@@ -1,0 +1,79 @@
+"use server";
+
+import { authActionClient } from "@/lib/auth-action";
+import { prisma } from "@/lib/prisma";
+import { revalidatePath } from "next/cache";
+import { Prisma } from "../../../../generated/prisma";
+import {
+  strategyMatrixCreateSchema,
+  strategyMatrixDeleteSchema,
+  strategyMatrixUpdateSchema,
+} from "./strategy-matrix-schema";
+
+export const createStrategyMatrixAction = authActionClient
+  .inputSchema(strategyMatrixCreateSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const matrix = await prisma.strategyMatrix.create({
+      data: {
+        userId: ctx.user.id,
+        title: parsedInput.title,
+        description: parsedInput.description,
+        myAxis: parsedInput.myAxis as unknown as Prisma.InputJsonValue,
+        opponentAxis:
+          parsedInput.opponentAxis as unknown as Prisma.InputJsonValue,
+        cells: parsedInput.cells as unknown as Prisma.InputJsonValue,
+      },
+    });
+
+    revalidatePath("/notes/strategy");
+    return { id: matrix.id };
+  });
+
+export const updateStrategyMatrixAction = authActionClient
+  .inputSchema(strategyMatrixUpdateSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const existing = await prisma.strategyMatrix.findFirst({
+      where: { id: parsedInput.id, userId: ctx.user.id },
+      select: { id: true },
+    });
+
+    if (!existing) {
+      throw new Error("Matrice introuvable");
+    }
+
+    const matrix = await prisma.strategyMatrix.update({
+      where: { id: parsedInput.id },
+      data: {
+        title: parsedInput.title,
+        description: parsedInput.description,
+        myAxis: parsedInput.myAxis as unknown as Prisma.InputJsonValue,
+        opponentAxis:
+          parsedInput.opponentAxis as unknown as Prisma.InputJsonValue,
+        cells: parsedInput.cells as unknown as Prisma.InputJsonValue,
+      },
+    });
+
+    revalidatePath("/notes/strategy");
+    revalidatePath(`/notes/strategy/${matrix.id}`);
+    return { id: matrix.id };
+  });
+
+export const deleteStrategyMatrixAction = authActionClient
+  .inputSchema(strategyMatrixDeleteSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const existing = await prisma.strategyMatrix.findFirst({
+      where: { id: parsedInput.id, userId: ctx.user.id },
+      select: { id: true },
+    });
+
+    if (!existing) {
+      throw new Error("Matrice introuvable");
+    }
+
+    await prisma.strategyMatrix.delete({
+      where: { id: parsedInput.id },
+    });
+
+    revalidatePath("/notes/strategy");
+    return { success: true };
+  });

--- a/src/components/features/strategy-matrix/strategy-matrix-axis-builder.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-axis-builder.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Plus, Trash2 } from "lucide-react";
+import type { Axis, Level, ResourceType } from "./strategy-matrix-schema";
+import { RESOURCE_TYPES } from "./strategy-matrix-schema";
+import {
+  MAX_LEVELS,
+  MIN_LEVELS,
+  RESOURCE_TYPE_LABELS,
+} from "./strategy-matrix-types";
+
+type Props = {
+  axis: Axis;
+  onChange: (axis: Axis) => void;
+  heading: string;
+};
+
+function generateLevelId(): string {
+  return `lvl-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function StrategyMatrixAxisBuilder({ axis, onChange, heading }: Props) {
+  const updateLabel = (label: string) => onChange({ ...axis, label });
+
+  const updateResource = (resource: ResourceType) =>
+    onChange({ ...axis, resource });
+
+  const updateLevel = (index: number, partial: Partial<Level>) => {
+    const levels = axis.levels.map((lvl, i) =>
+      i === index ? { ...lvl, ...partial } : lvl,
+    );
+    onChange({ ...axis, levels });
+  };
+
+  const addLevel = () => {
+    if (axis.levels.length >= MAX_LEVELS) return;
+    const newLevel: Level = {
+      id: generateLevelId(),
+      label: `Niveau ${axis.levels.length + 1}`,
+      order: axis.levels.length,
+    };
+    onChange({ ...axis, levels: [...axis.levels, newLevel] });
+  };
+
+  const removeLevel = (index: number) => {
+    if (axis.levels.length <= MIN_LEVELS) return;
+    const levels = axis.levels
+      .filter((_, i) => i !== index)
+      .map((lvl, i) => ({ ...lvl, order: i }));
+    onChange({ ...axis, levels });
+  };
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <h3 className="text-sm font-semibold">{heading}</h3>
+
+      <div className="space-y-2">
+        <Label htmlFor={`axis-label-${heading}`}>Libellé de l&apos;axe</Label>
+        <Input
+          id={`axis-label-${heading}`}
+          value={axis.label}
+          onChange={(e) => updateLabel(e.target.value)}
+          placeholder="Ex: Mon meter"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Type de ressource</Label>
+        <Select
+          value={axis.resource}
+          onValueChange={(v) => updateResource(v as ResourceType)}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {RESOURCE_TYPES.map((type) => (
+              <SelectItem key={type} value={type}>
+                {RESOURCE_TYPE_LABELS[type]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label>
+            Niveaux ({axis.levels.length}/{MAX_LEVELS})
+          </Label>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addLevel}
+            disabled={axis.levels.length >= MAX_LEVELS}
+          >
+            <Plus className="mr-1 h-3 w-3" />
+            Ajouter
+          </Button>
+        </div>
+        <div className="space-y-2">
+          {axis.levels.map((level, index) => (
+            <div key={level.id} className="flex items-center gap-2">
+              <Input
+                value={level.label}
+                onChange={(e) => updateLevel(index, { label: e.target.value })}
+                placeholder={`Niveau ${index + 1}`}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => removeLevel(index)}
+                disabled={axis.levels.length <= MIN_LEVELS}
+                aria-label={`Supprimer ${level.label}`}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/strategy-matrix/strategy-matrix-cell-editor.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-cell-editor.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Eye, Pencil } from "lucide-react";
+import { useEffect, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { MAX_CELL_LENGTH } from "./strategy-matrix-types";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialContent: string;
+  myLevelLabel: string;
+  opponentLevelLabel: string;
+  onSave: (content: string) => void;
+};
+
+export function StrategyMatrixCellEditor({
+  open,
+  onOpenChange,
+  initialContent,
+  myLevelLabel,
+  opponentLevelLabel,
+  onSave,
+}: Props) {
+  const [content, setContent] = useState(initialContent);
+  const [showPreview, setShowPreview] = useState(false);
+  const [confirmCloseOpen, setConfirmCloseOpen] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setContent(initialContent);
+      setShowPreview(false);
+      setConfirmCloseOpen(false);
+    }
+  }, [open, initialContent]);
+
+  const isDirty = content !== initialContent;
+
+  const handleSave = () => {
+    onSave(content);
+    onOpenChange(false);
+  };
+
+  const requestClose = () => {
+    if (isDirty) {
+      setConfirmCloseOpen(true);
+      return;
+    }
+    onOpenChange(false);
+  };
+
+  const handleDialogOpenChange = (next: boolean) => {
+    if (!next) {
+      requestClose();
+      return;
+    }
+    onOpenChange(next);
+  };
+
+  const handleConfirmDiscard = () => {
+    setConfirmCloseOpen(false);
+    onOpenChange(false);
+  };
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={handleDialogOpenChange}>
+        <DialogContent
+          className="sm:max-w-2xl"
+          showCloseButton={false}
+          onEscapeKeyDown={(event) => {
+            if (isDirty) {
+              event.preventDefault();
+              setConfirmCloseOpen(true);
+            }
+          }}
+          onPointerDownOutside={(event) => {
+            if (isDirty) {
+              event.preventDefault();
+              setConfirmCloseOpen(true);
+            }
+          }}
+          onInteractOutside={(event) => {
+            if (isDirty) {
+              event.preventDefault();
+            }
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>
+              {myLevelLabel} × {opponentLevelLabel}
+            </DialogTitle>
+            <DialogDescription>
+              Décrivez votre stratégie pour cette combinaison d&apos;états.
+              Markdown supporté.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground text-xs">
+                {content.length} / {MAX_CELL_LENGTH}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowPreview((v) => !v)}
+              >
+                {showPreview ? (
+                  <>
+                    <Pencil className="mr-2 h-3 w-3" />
+                    Édition
+                  </>
+                ) : (
+                  <>
+                    <Eye className="mr-2 h-3 w-3" />
+                    Aperçu
+                  </>
+                )}
+              </Button>
+            </div>
+
+            {showPreview ? (
+              <div className="prose prose-invert border-border bg-muted text-foreground min-h-[200px] max-w-none rounded-md border p-3 text-sm">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {content || "*Aucun contenu*"}
+                </ReactMarkdown>
+              </div>
+            ) : (
+              <Textarea
+                value={content}
+                onChange={(e) =>
+                  setContent(e.target.value.slice(0, MAX_CELL_LENGTH))
+                }
+                placeholder="Ex: Punish max → cr.HP xx Super..."
+                className="min-h-[200px]"
+              />
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={requestClose}>
+              Annuler
+            </Button>
+            <Button type="button" onClick={handleSave}>
+              Enregistrer
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={confirmCloseOpen} onOpenChange={setConfirmCloseOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Abandonner les modifications ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Les changements apportés à cette cellule ne sont pas enregistrés.
+              Voulez-vous vraiment fermer l&apos;éditeur ?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Continuer l&apos;édition</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmDiscard}>
+              Abandonner
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/features/strategy-matrix/strategy-matrix-form.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-form.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useAction } from "next-safe-action/hooks";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import {
+  createStrategyMatrixAction,
+  updateStrategyMatrixAction,
+} from "./strategy-matrix-action";
+import { StrategyMatrixAxisBuilder } from "./strategy-matrix-axis-builder";
+import { StrategyMatrixCellEditor } from "./strategy-matrix-cell-editor";
+import { StrategyMatrixGrid } from "./strategy-matrix-grid";
+import {
+  strategyMatrixCreateSchema,
+  type Axis,
+  type StrategyMatrixCreateInput,
+} from "./strategy-matrix-schema";
+import {
+  STRATEGY_MATRIX_TEMPLATES,
+  type StrategyMatrixTemplate,
+} from "./strategy-matrix-templates";
+import { StrategyMatrixTemplateSelector } from "./strategy-matrix-template-selector";
+import {
+  buildCellLookup,
+  cellKey,
+  reconcileCells,
+} from "./strategy-matrix-types";
+
+type Props =
+  | {
+      mode: "create";
+      initialTemplate?: StrategyMatrixTemplate;
+      matrixId?: undefined;
+      initialData?: undefined;
+    }
+  | {
+      mode: "edit";
+      matrixId: string;
+      initialData: StrategyMatrixCreateInput;
+      initialTemplate?: undefined;
+    };
+
+type EditingCell = {
+  myLevelId: string;
+  opponentLevelId: string;
+} | null;
+
+export function StrategyMatrixForm(props: Props) {
+  const router = useRouter();
+  const fallback = props.initialTemplate ?? STRATEGY_MATRIX_TEMPLATES[0];
+  const initialValues: StrategyMatrixCreateInput =
+    props.mode === "edit"
+      ? props.initialData
+      : {
+          title: fallback.title,
+          description: undefined,
+          myAxis: fallback.myAxis,
+          opponentAxis: fallback.opponentAxis,
+          cells: fallback.cells,
+        };
+
+  const [showTemplatePicker, setShowTemplatePicker] = useState(false);
+  const [editingCell, setEditingCell] = useState<EditingCell>(null);
+
+  const form = useForm<StrategyMatrixCreateInput>({
+    resolver: zodResolver(strategyMatrixCreateSchema),
+    defaultValues: initialValues,
+    mode: "onSubmit",
+  });
+
+  const myAxis = form.watch("myAxis");
+  const opponentAxis = form.watch("opponentAxis");
+  const cells = form.watch("cells");
+
+  const createAction = useAction(createStrategyMatrixAction, {
+    onSuccess: ({ data }) => {
+      toast.success("Matrice créée");
+      if (data?.id) router.push(`/notes/strategy/${data.id}`);
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? "Erreur lors de la création");
+    },
+  });
+
+  const updateAction = useAction(updateStrategyMatrixAction, {
+    onSuccess: () => {
+      toast.success("Matrice mise à jour");
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? "Erreur lors de la mise à jour");
+    },
+  });
+
+  const isPending = createAction.isPending || updateAction.isPending;
+
+  const handleSelectTemplate = (template: StrategyMatrixTemplate) => {
+    form.reset({
+      title: template.title,
+      description: undefined,
+      myAxis: template.myAxis,
+      opponentAxis: template.opponentAxis,
+      cells: template.cells,
+    });
+    setShowTemplatePicker(false);
+  };
+
+  const handleAxisChange = (
+    field: "myAxis" | "opponentAxis",
+    nextAxis: Axis,
+  ) => {
+    form.setValue(field, nextAxis, { shouldDirty: true });
+    const nextMy = field === "myAxis" ? nextAxis : myAxis;
+    const nextOpp = field === "opponentAxis" ? nextAxis : opponentAxis;
+    const nextCells = reconcileCells(form.getValues("cells"), nextMy, nextOpp);
+    form.setValue("cells", nextCells, { shouldDirty: true });
+  };
+
+  const handleCellSave = (content: string) => {
+    if (!editingCell) return;
+    const lookup = buildCellLookup(form.getValues("cells"));
+    const key = cellKey(editingCell.myLevelId, editingCell.opponentLevelId);
+    lookup.set(key, {
+      myLevelId: editingCell.myLevelId,
+      opponentLevelId: editingCell.opponentLevelId,
+      content,
+    });
+    form.setValue("cells", Array.from(lookup.values()), { shouldDirty: true });
+  };
+
+  const onSubmit = (data: StrategyMatrixCreateInput) => {
+    const reconciled = reconcileCells(
+      data.cells,
+      data.myAxis,
+      data.opponentAxis,
+    );
+    const payload = { ...data, cells: reconciled };
+    if (props.mode === "edit") {
+      updateAction.execute({ id: props.matrixId, ...payload });
+    } else {
+      createAction.execute(payload);
+    }
+  };
+
+  const editingMyLabel = editingCell
+    ? (myAxis.levels.find((l) => l.id === editingCell.myLevelId)?.label ?? "")
+    : "";
+  const editingOppLabel = editingCell
+    ? (opponentAxis.levels.find((l) => l.id === editingCell.opponentLevelId)
+        ?.label ?? "")
+    : "";
+  const editingContent = editingCell
+    ? (cells.find(
+        (c) =>
+          c.myLevelId === editingCell.myLevelId &&
+          c.opponentLevelId === editingCell.opponentLevelId,
+      )?.content ?? "")
+    : "";
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {props.mode === "create" && (
+          <div className="space-y-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setShowTemplatePicker((v) => !v)}
+            >
+              {showTemplatePicker ? "Masquer les modèles" : "Choisir un modèle"}
+            </Button>
+            {showTemplatePicker && (
+              <StrategyMatrixTemplateSelector onSelect={handleSelectTemplate} />
+            )}
+          </div>
+        )}
+
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Titre</FormLabel>
+              <FormControl>
+                <Input placeholder="Ex: Stratégie défensive Ken" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Description (optionnelle)</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Contexte ou conditions générales d'utilisation de cette matrice"
+                  value={field.value ?? ""}
+                  onChange={field.onChange}
+                  className="min-h-[60px]"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <StrategyMatrixAxisBuilder
+            heading="Mon état (colonnes)"
+            axis={myAxis}
+            onChange={(next) => handleAxisChange("myAxis", next)}
+          />
+          <StrategyMatrixAxisBuilder
+            heading="État adversaire (lignes)"
+            axis={opponentAxis}
+            onChange={(next) => handleAxisChange("opponentAxis", next)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <FormLabel>Matrice</FormLabel>
+          <FormDescription>
+            Cliquez sur une cellule pour éditer son contenu en markdown.
+          </FormDescription>
+          <StrategyMatrixGrid
+            myAxis={myAxis}
+            opponentAxis={opponentAxis}
+            cells={cells}
+            onCellClick={(myLevelId, opponentLevelId) =>
+              setEditingCell({ myLevelId, opponentLevelId })
+            }
+          />
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.back()}
+            disabled={isPending}
+          >
+            Annuler
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {isPending
+              ? "Enregistrement…"
+              : props.mode === "edit"
+                ? "Mettre à jour"
+                : "Créer la matrice"}
+          </Button>
+        </div>
+
+        <StrategyMatrixCellEditor
+          open={editingCell !== null}
+          onOpenChange={(open) => !open && setEditingCell(null)}
+          initialContent={editingContent}
+          myLevelLabel={editingMyLabel}
+          opponentLevelLabel={editingOppLabel}
+          onSave={handleCellSave}
+        />
+      </form>
+    </Form>
+  );
+}

--- a/src/components/features/strategy-matrix/strategy-matrix-grid.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-grid.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { Axis, Cell } from "./strategy-matrix-schema";
+import { buildCellLookup, cellKey } from "./strategy-matrix-types";
+
+type Props = {
+  myAxis: Axis;
+  opponentAxis: Axis;
+  cells: Cell[];
+  onCellClick?: (myLevelId: string, opponentLevelId: string) => void;
+  readOnly?: boolean;
+};
+
+const PREVIEW_LENGTH = 80;
+
+function previewContent(content: string): string {
+  if (!content) return "";
+  if (content.length <= PREVIEW_LENGTH) return content;
+  return content.slice(0, PREVIEW_LENGTH).trimEnd() + "…";
+}
+
+export function StrategyMatrixGrid({
+  myAxis,
+  opponentAxis,
+  cells,
+  onCellClick,
+  readOnly = false,
+}: Props) {
+  const lookup = buildCellLookup(cells);
+  const columnCount = myAxis.levels.length;
+
+  return (
+    <div className="overflow-x-auto">
+      <div
+        className="bg-border grid min-w-fit gap-px rounded-lg border"
+        style={{
+          gridTemplateColumns: `minmax(140px, 200px) repeat(${columnCount}, minmax(160px, 1fr))`,
+        }}
+      >
+        <div className="bg-muted text-muted-foreground flex items-center justify-center p-3 text-xs font-semibold">
+          {opponentAxis.label} ↓ / {myAxis.label} →
+        </div>
+
+        {myAxis.levels.map((my) => (
+          <div
+            key={my.id}
+            className="bg-muted text-foreground flex items-center justify-center p-3 text-center text-sm font-semibold"
+          >
+            {my.label}
+          </div>
+        ))}
+
+        {opponentAxis.levels.map((opp) => (
+          <div key={opp.id} className="contents">
+            <div className="bg-muted text-foreground flex items-center justify-center p-3 text-center text-sm font-semibold">
+              {opp.label}
+            </div>
+            {myAxis.levels.map((my) => {
+              const cell = lookup.get(cellKey(my.id, opp.id));
+              const content = cell?.content ?? "";
+              const isEmpty = !content;
+              return (
+                <button
+                  key={cellKey(my.id, opp.id)}
+                  type="button"
+                  onClick={() => !readOnly && onCellClick?.(my.id, opp.id)}
+                  disabled={readOnly}
+                  className={cn(
+                    "bg-card text-foreground min-h-[100px] p-3 text-left text-sm transition-colors",
+                    !readOnly && "hover:bg-accent cursor-pointer",
+                    readOnly && "cursor-default",
+                    isEmpty && "text-muted-foreground italic",
+                  )}
+                >
+                  {isEmpty
+                    ? "Vide — cliquez pour éditer"
+                    : previewContent(content)}
+                </button>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/strategy-matrix/strategy-matrix-help-dialog.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-help-dialog.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { HelpCircle } from "lucide-react";
+import { useState } from "react";
+
+export function StrategyMatrixHelpDialog() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button type="button" variant="outline" size="sm">
+          <HelpCircle className="mr-2 h-4 w-4" />
+          Mode d&apos;emploi
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Comment utiliser une matrice de stratégie ?</DialogTitle>
+          <DialogDescription>
+            Une matrice croise <strong>votre état</strong> (colonnes) et{" "}
+            <strong>l&apos;état adverse</strong> (lignes). Chaque cellule
+            contient l&apos;action optimale pour cette combinaison de
+            ressources.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6 text-sm">
+          <section className="space-y-2">
+            <h3 className="text-base font-semibold">Étapes</h3>
+            <ol className="text-muted-foreground list-decimal space-y-1.5 pl-5">
+              <li>
+                <strong className="text-foreground">Choisir un modèle</strong>{" "}
+                (HP × Meter, Drive × Position, ou Vide) ou partir d&apos;une
+                base existante.
+              </li>
+              <li>
+                <strong className="text-foreground">Donner un titre</strong>{" "}
+                clair (ex: «&nbsp;Ken vs Juri — défense&nbsp;»).
+              </li>
+              <li>
+                <strong className="text-foreground">Définir les axes</strong> :
+                un libellé, un type de ressource (HP, Meter, Drive, Position,
+                Custom) et de 2 à 5 niveaux par axe.
+              </li>
+              <li>
+                <strong className="text-foreground">Cliquer une cellule</strong>{" "}
+                pour ouvrir l&apos;éditeur markdown et décrire la stratégie
+                optimale.
+              </li>
+              <li>
+                <strong className="text-foreground">Enregistrer</strong> — la
+                matrice est consultable ensuite avant un match.
+              </li>
+            </ol>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-base font-semibold">Exemple concret</h3>
+            <p className="text-muted-foreground">
+              Matrice : <em>Mon Drive Gauge</em> (colonnes) ×{" "}
+              <em>Position adversaire</em> (lignes).
+            </p>
+            <div className="overflow-x-auto rounded-md border">
+              <table className="w-full text-xs">
+                <thead className="bg-muted">
+                  <tr>
+                    <th className="p-2 text-left font-semibold"></th>
+                    <th className="p-2 text-left font-semibold">
+                      Drive plein
+                    </th>
+                    <th className="p-2 text-left font-semibold">
+                      Drive moyen
+                    </th>
+                    <th className="p-2 text-left font-semibold">Burnout</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-t">
+                    <td className="bg-muted/40 p-2 font-semibold">Midscreen</td>
+                    <td className="p-2">
+                      Pression DR + mixup, hit confirm Super 2
+                    </td>
+                    <td className="p-2">Whiff punish safe, garder 1 bar</td>
+                    <td className="p-2">
+                      Backdash pour reset spacing, bloquer haut
+                    </td>
+                  </tr>
+                  <tr className="border-t">
+                    <td className="bg-muted/40 p-2 font-semibold">Corner</td>
+                    <td className="p-2">
+                      Throw loop unreactable, kill confirm
+                    </td>
+                    <td className="p-2">
+                      Frame trap cr.MK xx DR → mixup overhead/low
+                    </td>
+                    <td className="p-2">
+                      Pas de DI possible, jouer pour timeout
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="text-muted-foreground italic">
+              Astuce : dans une cellule, le markdown est supporté (gras, listes,
+              flèches `→`). Compteur 2000 caractères max par cellule.
+            </p>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-base font-semibold">Bonnes pratiques</h3>
+            <ul className="text-muted-foreground list-disc space-y-1 pl-5">
+              <li>
+                Une matrice = <strong>une situation</strong> précise (un
+                matchup, une phase de jeu).
+              </li>
+              <li>
+                Garder 2-3 niveaux par axe au début. Ajouter de la granularité
+                quand vous maîtrisez la base.
+              </li>
+              <li>
+                Si vous modifiez un axe (ajout/suppression de niveau), les
+                cellules orphelines sont purgées et les nouvelles cellules sont
+                créées vides.
+              </li>
+              <li>
+                Consultable depuis <code>/notes/strategy</code>. Idéal avant un
+                match comme fiche de révision.
+              </li>
+            </ul>
+          </section>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={() => setOpen(false)}>Compris</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/features/strategy-matrix/strategy-matrix-list.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-list.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { useAction } from "next-safe-action/hooks";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { axisSchema } from "./strategy-matrix-schema";
+import type { StrategyMatrixListItem } from "../../../../prisma/query/strategy-matrix.query";
+import { deleteStrategyMatrixAction } from "./strategy-matrix-action";
+
+type Props = {
+  matrices: StrategyMatrixListItem[];
+};
+
+function safeAxisLabel(value: unknown): string {
+  const parsed = axisSchema.safeParse(value);
+  return parsed.success ? parsed.data.label : "—";
+}
+
+export function StrategyMatrixList({ matrices }: Props) {
+  const router = useRouter();
+  const { execute, isPending } = useAction(deleteStrategyMatrixAction, {
+    onSuccess: () => {
+      toast.success("Matrice supprimée");
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? "Erreur lors de la suppression");
+    },
+  });
+
+  if (matrices.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-4 rounded-lg border border-dashed p-12 text-center">
+        <p className="text-muted-foreground">Aucune matrice pour le moment.</p>
+        <Button asChild>
+          <Link href="/notes/strategy/new">Créer ma première matrice</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {matrices.map((matrix) => (
+        <Card key={matrix.id} className="flex flex-col gap-3 p-4">
+          <div className="space-y-1">
+            <h3 className="line-clamp-1 font-semibold">{matrix.title}</h3>
+            {matrix.description && (
+              <p className="text-muted-foreground line-clamp-2 text-sm">
+                {matrix.description}
+              </p>
+            )}
+          </div>
+          <div className="text-muted-foreground text-xs">
+            {safeAxisLabel(matrix.myAxis)} ×{" "}
+            {safeAxisLabel(matrix.opponentAxis)}
+          </div>
+          <div className="mt-auto flex gap-2">
+            <Button asChild size="sm" className="flex-1">
+              <Link href={`/notes/strategy/${matrix.id}`}>Ouvrir</Link>
+            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="outline" size="sm" disabled={isPending}>
+                  Supprimer
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Supprimer cette matrice ?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Cette action est irréversible. La matrice « {matrix.title} »
+                    sera définitivement supprimée.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Annuler</AlertDialogCancel>
+                  <AlertDialogAction onClick={() => execute({ id: matrix.id })}>
+                    Supprimer
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/features/strategy-matrix/strategy-matrix-schema.test.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-schema.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  axisSchema,
+  cellSchema,
+  strategyMatrixCreateSchema,
+} from "./strategy-matrix-schema";
+import { STRATEGY_MATRIX_TEMPLATES } from "./strategy-matrix-templates";
+
+describe("axisSchema", () => {
+  const validAxis = {
+    label: "Mon meter",
+    resource: "METER" as const,
+    levels: [
+      { id: "a", label: "Plein", order: 0 },
+      { id: "b", label: "Vide", order: 1 },
+    ],
+  };
+
+  it("accepts a valid axis", () => {
+    expect(axisSchema.safeParse(validAxis).success).toBe(true);
+  });
+
+  it("rejects fewer than 2 levels", () => {
+    const result = axisSchema.safeParse({
+      ...validAxis,
+      levels: [{ id: "a", label: "Plein", order: 0 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects more than 5 levels", () => {
+    const result = axisSchema.safeParse({
+      ...validAxis,
+      levels: Array.from({ length: 6 }, (_, i) => ({
+        id: `id-${i}`,
+        label: `L${i}`,
+        order: i,
+      })),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects duplicated level ids", () => {
+    const result = axisSchema.safeParse({
+      ...validAxis,
+      levels: [
+        { id: "dup", label: "A", order: 0 },
+        { id: "dup", label: "B", order: 1 },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("cellSchema", () => {
+  it("rejects content longer than 2000 chars", () => {
+    const result = cellSchema.safeParse({
+      myLevelId: "a",
+      opponentLevelId: "b",
+      content: "x".repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts empty content", () => {
+    const result = cellSchema.safeParse({
+      myLevelId: "a",
+      opponentLevelId: "b",
+      content: "",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("strategyMatrixCreateSchema", () => {
+  const baseTemplate = STRATEGY_MATRIX_TEMPLATES[0];
+
+  it("accepts each template", () => {
+    for (const template of STRATEGY_MATRIX_TEMPLATES) {
+      const result = strategyMatrixCreateSchema.safeParse({
+        title: template.title,
+        myAxis: template.myAxis,
+        opponentAxis: template.opponentAxis,
+        cells: template.cells,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects orphan cells referencing unknown levels", () => {
+    const result = strategyMatrixCreateSchema.safeParse({
+      title: baseTemplate.title,
+      myAxis: baseTemplate.myAxis,
+      opponentAxis: baseTemplate.opponentAxis,
+      cells: [
+        {
+          myLevelId: "does-not-exist",
+          opponentLevelId: baseTemplate.opponentAxis.levels[0].id,
+          content: "",
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty title", () => {
+    const result = strategyMatrixCreateSchema.safeParse({
+      title: "",
+      myAxis: baseTemplate.myAxis,
+      opponentAxis: baseTemplate.opponentAxis,
+      cells: baseTemplate.cells,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/components/features/strategy-matrix/strategy-matrix-schema.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-schema.ts
@@ -1,0 +1,90 @@
+import z from "zod";
+
+export const RESOURCE_TYPES = [
+  "HP",
+  "METER",
+  "DRIVE",
+  "POSITION",
+  "CUSTOM",
+] as const;
+
+export const levelSchema = z.object({
+  id: z.string().min(1),
+  label: z
+    .string()
+    .min(1, { error: "Le libellé du niveau est requis" })
+    .max(60, { error: "Maximum 60 caractères" }),
+  order: z.number().int().min(0),
+});
+
+export const axisSchema = z
+  .object({
+    label: z
+      .string()
+      .min(1, { error: "Le libellé de l'axe est requis" })
+      .max(60, { error: "Maximum 60 caractères" }),
+    resource: z.enum(RESOURCE_TYPES),
+    levels: z
+      .array(levelSchema)
+      .min(2, { error: "Au moins 2 niveaux requis" })
+      .max(5, { error: "Maximum 5 niveaux" }),
+  })
+  .refine(
+    (axis) => new Set(axis.levels.map((l) => l.id)).size === axis.levels.length,
+    { error: "Les identifiants de niveaux doivent être uniques" },
+  );
+
+export const cellSchema = z.object({
+  myLevelId: z.string().min(1),
+  opponentLevelId: z.string().min(1),
+  content: z
+    .string()
+    .max(2000, { error: "Maximum 2000 caractères par cellule" }),
+});
+
+const matrixBaseSchema = z
+  .object({
+    title: z
+      .string()
+      .min(1, { error: "Le titre est requis" })
+      .max(120, { error: "Maximum 120 caractères" }),
+    description: z
+      .string()
+      .max(500, { error: "Maximum 500 caractères" })
+      .optional(),
+    myAxis: axisSchema,
+    opponentAxis: axisSchema,
+    cells: z.array(cellSchema),
+  })
+  .refine(
+    (data) => {
+      const myIds = new Set(data.myAxis.levels.map((l) => l.id));
+      const oppIds = new Set(data.opponentAxis.levels.map((l) => l.id));
+      return data.cells.every(
+        (c) => myIds.has(c.myLevelId) && oppIds.has(c.opponentLevelId),
+      );
+    },
+    { error: "Cellules orphelines détectées" },
+  );
+
+export const strategyMatrixCreateSchema = matrixBaseSchema;
+
+export const strategyMatrixUpdateSchema = z.intersection(
+  z.object({ id: z.string().min(1) }),
+  matrixBaseSchema,
+);
+
+export const strategyMatrixDeleteSchema = z.object({
+  id: z.string().min(1, { error: "L'ID de la matrice est requis" }),
+});
+
+export type Level = z.infer<typeof levelSchema>;
+export type Axis = z.infer<typeof axisSchema>;
+export type Cell = z.infer<typeof cellSchema>;
+export type StrategyMatrixCreateInput = z.infer<
+  typeof strategyMatrixCreateSchema
+>;
+export type StrategyMatrixUpdateInput = z.infer<
+  typeof strategyMatrixUpdateSchema
+>;
+export type ResourceType = (typeof RESOURCE_TYPES)[number];

--- a/src/components/features/strategy-matrix/strategy-matrix-template-selector.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-template-selector.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  STRATEGY_MATRIX_TEMPLATES,
+  type StrategyMatrixTemplate,
+} from "./strategy-matrix-templates";
+
+type Props = {
+  onSelect: (template: StrategyMatrixTemplate) => void;
+};
+
+export function StrategyMatrixTemplateSelector({ onSelect }: Props) {
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      {STRATEGY_MATRIX_TEMPLATES.map((template) => (
+        <Card key={template.id} className="flex flex-col gap-3 p-4">
+          <div>
+            <h3 className="font-semibold">{template.name}</h3>
+            <p className="text-muted-foreground mt-1 text-sm">
+              {template.description}
+            </p>
+          </div>
+          <div className="text-muted-foreground text-xs">
+            {template.myAxis.levels.length} ×{" "}
+            {template.opponentAxis.levels.length} cellules
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onSelect(template)}
+            className="mt-auto"
+          >
+            Utiliser ce modèle
+          </Button>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/features/strategy-matrix/strategy-matrix-templates.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-templates.ts
@@ -1,0 +1,99 @@
+import type { Axis, Cell } from "./strategy-matrix-schema";
+import { createEmptyCells } from "./strategy-matrix-types";
+
+export type StrategyMatrixTemplate = {
+  id: string;
+  name: string;
+  description: string;
+  title: string;
+  myAxis: Axis;
+  opponentAxis: Axis;
+  cells: Cell[];
+};
+
+const hpMeterMyAxis: Axis = {
+  label: "Mon HP",
+  resource: "HP",
+  levels: [
+    { id: "hp-high", label: "Haut", order: 0 },
+    { id: "hp-mid", label: "Moyen", order: 1 },
+    { id: "hp-low", label: "Bas", order: 2 },
+  ],
+};
+
+const hpMeterOpponentAxis: Axis = {
+  label: "Meter adversaire",
+  resource: "METER",
+  levels: [
+    { id: "meter-full", label: "Plein", order: 0 },
+    { id: "meter-mid", label: "Moyen", order: 1 },
+    { id: "meter-empty", label: "Vide", order: 2 },
+  ],
+};
+
+const driveMyAxis: Axis = {
+  label: "Mon Drive Gauge",
+  resource: "DRIVE",
+  levels: [
+    { id: "drive-full", label: "Plein", order: 0 },
+    { id: "drive-mid", label: "Moyen", order: 1 },
+    { id: "drive-burnout", label: "Burnout", order: 2 },
+  ],
+};
+
+const positionOpponentAxis: Axis = {
+  label: "Position adversaire",
+  resource: "POSITION",
+  levels: [
+    { id: "pos-midscreen", label: "Midscreen", order: 0 },
+    { id: "pos-corner", label: "Corner", order: 1 },
+  ],
+};
+
+const customMyAxis: Axis = {
+  label: "Mon état",
+  resource: "CUSTOM",
+  levels: [
+    { id: "my-a", label: "Niveau A", order: 0 },
+    { id: "my-b", label: "Niveau B", order: 1 },
+  ],
+};
+
+const customOpponentAxis: Axis = {
+  label: "État adversaire",
+  resource: "CUSTOM",
+  levels: [
+    { id: "opp-a", label: "Niveau A", order: 0 },
+    { id: "opp-b", label: "Niveau B", order: 1 },
+  ],
+};
+
+export const STRATEGY_MATRIX_TEMPLATES: StrategyMatrixTemplate[] = [
+  {
+    id: "hp-vs-meter",
+    name: "HP × Meter (générique)",
+    description: "Stratégie selon votre HP et le meter adverse",
+    title: "Stratégie HP × Meter",
+    myAxis: hpMeterMyAxis,
+    opponentAxis: hpMeterOpponentAxis,
+    cells: createEmptyCells(hpMeterMyAxis, hpMeterOpponentAxis),
+  },
+  {
+    id: "drive-vs-position",
+    name: "Drive Gauge × Position (SF6)",
+    description: "Stratégie selon votre Drive et la position adverse",
+    title: "Stratégie Drive × Position",
+    myAxis: driveMyAxis,
+    opponentAxis: positionOpponentAxis,
+    cells: createEmptyCells(driveMyAxis, positionOpponentAxis),
+  },
+  {
+    id: "custom-blank",
+    name: "Vide / Personnalisé",
+    description: "Démarrer avec une matrice vierge à personnaliser",
+    title: "Nouvelle matrice",
+    myAxis: customMyAxis,
+    opponentAxis: customOpponentAxis,
+    cells: createEmptyCells(customMyAxis, customOpponentAxis),
+  },
+];

--- a/src/components/features/strategy-matrix/strategy-matrix-types.test.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-types.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { Axis } from "./strategy-matrix-schema";
+import { STRATEGY_MATRIX_TEMPLATES } from "./strategy-matrix-templates";
+import {
+  buildCellLookup,
+  cellKey,
+  createEmptyCells,
+  reconcileCells,
+} from "./strategy-matrix-types";
+
+describe("createEmptyCells", () => {
+  it("creates the cartesian product of axes", () => {
+    const myAxis: Axis = {
+      label: "X",
+      resource: "CUSTOM",
+      levels: [
+        { id: "a", label: "A", order: 0 },
+        { id: "b", label: "B", order: 1 },
+      ],
+    };
+    const opponentAxis: Axis = {
+      label: "Y",
+      resource: "CUSTOM",
+      levels: [
+        { id: "c", label: "C", order: 0 },
+        { id: "d", label: "D", order: 1 },
+        { id: "e", label: "E", order: 2 },
+      ],
+    };
+    const cells = createEmptyCells(myAxis, opponentAxis);
+    expect(cells).toHaveLength(6);
+    expect(cells.every((c) => c.content === "")).toBe(true);
+  });
+});
+
+describe("reconcileCells", () => {
+  const template = STRATEGY_MATRIX_TEMPLATES[0];
+
+  it("preserves existing cells when axes are unchanged", () => {
+    const filled = template.cells.map((c, i) => ({
+      ...c,
+      content: `note-${i}`,
+    }));
+    const reconciled = reconcileCells(
+      filled,
+      template.myAxis,
+      template.opponentAxis,
+    );
+    expect(reconciled.map((c) => c.content)).toEqual(
+      filled.map((c) => c.content),
+    );
+  });
+
+  it("drops orphan cells when a level is removed", () => {
+    const trimmedMyAxis: Axis = {
+      ...template.myAxis,
+      levels: template.myAxis.levels.slice(0, 2),
+    };
+    const filled = template.cells.map((c) => ({ ...c, content: "x" }));
+    const reconciled = reconcileCells(
+      filled,
+      trimmedMyAxis,
+      template.opponentAxis,
+    );
+    expect(reconciled).toHaveLength(
+      trimmedMyAxis.levels.length * template.opponentAxis.levels.length,
+    );
+    const validIds = new Set(trimmedMyAxis.levels.map((l) => l.id));
+    expect(reconciled.every((c) => validIds.has(c.myLevelId))).toBe(true);
+  });
+
+  it("creates blank cells for newly added levels", () => {
+    const extendedMyAxis: Axis = {
+      ...template.myAxis,
+      levels: [
+        ...template.myAxis.levels,
+        {
+          id: "hp-new",
+          label: "Nouveau",
+          order: template.myAxis.levels.length,
+        },
+      ],
+    };
+    const filled = template.cells.map((c) => ({ ...c, content: "kept" }));
+    const reconciled = reconcileCells(
+      filled,
+      extendedMyAxis,
+      template.opponentAxis,
+    );
+    const newCells = reconciled.filter((c) => c.myLevelId === "hp-new");
+    expect(newCells).toHaveLength(template.opponentAxis.levels.length);
+    expect(newCells.every((c) => c.content === "")).toBe(true);
+  });
+});
+
+describe("buildCellLookup", () => {
+  it("indexes cells by composite key", () => {
+    const cells = [
+      { myLevelId: "a", opponentLevelId: "x", content: "1" },
+      { myLevelId: "a", opponentLevelId: "y", content: "2" },
+      { myLevelId: "b", opponentLevelId: "x", content: "3" },
+    ];
+    const lookup = buildCellLookup(cells);
+    expect(lookup.get(cellKey("a", "x"))?.content).toBe("1");
+    expect(lookup.get(cellKey("b", "x"))?.content).toBe("3");
+    expect(lookup.get(cellKey("z", "z"))).toBeUndefined();
+  });
+});

--- a/src/components/features/strategy-matrix/strategy-matrix-types.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-types.ts
@@ -1,0 +1,63 @@
+import type { Axis, Cell, ResourceType } from "./strategy-matrix-schema";
+
+export const RESOURCE_TYPE_LABELS: Record<ResourceType, string> = {
+  HP: "Vie",
+  METER: "Jauge Super",
+  DRIVE: "Drive Gauge",
+  POSITION: "Position",
+  CUSTOM: "Personnalisé",
+};
+
+export const MIN_LEVELS = 2;
+export const MAX_LEVELS = 5;
+export const MAX_CELL_LENGTH = 2000;
+export const MAX_TITLE_LENGTH = 120;
+export const MAX_DESCRIPTION_LENGTH = 500;
+
+export function cellKey(myLevelId: string, opponentLevelId: string): string {
+  return `${myLevelId}::${opponentLevelId}`;
+}
+
+export function buildCellLookup(cells: Cell[]): Map<string, Cell> {
+  const map = new Map<string, Cell>();
+  for (const cell of cells) {
+    map.set(cellKey(cell.myLevelId, cell.opponentLevelId), cell);
+  }
+  return map;
+}
+
+export function createEmptyCells(myAxis: Axis, opponentAxis: Axis): Cell[] {
+  const cells: Cell[] = [];
+  for (const my of myAxis.levels) {
+    for (const opp of opponentAxis.levels) {
+      cells.push({
+        myLevelId: my.id,
+        opponentLevelId: opp.id,
+        content: "",
+      });
+    }
+  }
+  return cells;
+}
+
+export function reconcileCells(
+  currentCells: Cell[],
+  myAxis: Axis,
+  opponentAxis: Axis,
+): Cell[] {
+  const lookup = buildCellLookup(currentCells);
+  const reconciled: Cell[] = [];
+  for (const my of myAxis.levels) {
+    for (const opp of opponentAxis.levels) {
+      const existing = lookup.get(cellKey(my.id, opp.id));
+      reconciled.push(
+        existing ?? {
+          myLevelId: my.id,
+          opponentLevelId: opp.id,
+          content: "",
+        },
+      );
+    }
+  }
+  return reconciled;
+}


### PR DESCRIPTION
## Summary

Implement Strategy Matrix (Matrice État × Action) V1 — a 2D interactive grid that materializes conditional decision-making by crossing user state (columns) vs opponent state (rows).

- Add StrategyMatrix Prisma model with flexible 2-axis system (myAxis, opponentAxis)
- Implement interactive CSS Grid with markdown cell editor and live preview
- Add form with 3 pre-filled templates (HP×Meter, Drive×Position, Vide custom)
- Create help dialog with tutorial and concrete examples
- Build axis editor with configurable levels (2-5 per axis)
- Add unsaved-changes confirmation on exit and cell reconciliation on axis edits
- Wire dashboard "Nouvelle matrice" button to /notes/strategy/new
- Include 14 unit tests for schema validation and reconciliation logic
- All TypeScript and ESLint checks passing

## Scope

V1 complete per spec (no character/matchup linking, no AI filling). Positions ComboTrack as unique FGC tool for state-aware strategy planning — unlike Flowchart.gg or Google Docs.

## Testing

- ✓ TypeScript strict mode
- ✓ ESLint all warnings fixed
- ✓ 14 passing unit tests (schemas + reconciliation)
- ✓ Manual: create/edit/delete/reconcile matrices
- ✓ CSS Grid responsive on mobile

## Files

21 files changed (+1769, -9)
- Pages: 3 new (list, create, edit)
- Components: 10 (grid, form, editor, axis builder, help, templates)
- Server: actions, queries, migrations
- Tests: schema validation, reconciliation logic