### PR TITLE
feat(strategy-matrix): V3 lite — IA cell fill via Groq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added: Strategy Matrix V1 (matrice État × Action standalone)
 
+### Added: Strategy Matrix V2 — matchup context (jeu, mon perso, perso adverse) + filtres liste
+
 ### Changed: Dashboard CTA "Nouvelle note personnelle" redirige vers la création de matrice de stratégie
 
 ## 2026-04-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-04-27
+
+### Added: Strategy Matrix V3 (lite) — IA pré-remplissage des cellules via Groq
+
 ## 2026-04-26
 
 ### Added: Strategy Matrix V1 (matrice État × Action standalone)

--- a/app/(dashboard)/notes/strategy/[id]/page.tsx
+++ b/app/(dashboard)/notes/strategy/[id]/page.tsx
@@ -2,7 +2,11 @@ import { StrategyMatrixForm } from "@/components/features/strategy-matrix/strate
 import { StrategyMatrixHelpDialog } from "@/components/features/strategy-matrix/strategy-matrix-help-dialog";
 import { requireAuth } from "@/lib/auth-utils";
 import { notFound } from "next/navigation";
-import { getStrategyMatrixById } from "../../../../../prisma/query/strategy-matrix.query";
+import {
+  getAllCharactersGroupedByGame,
+  getGameOptions,
+  getStrategyMatrixById,
+} from "../../../../../prisma/query/strategy-matrix.query";
 
 export default async function StrategyMatrixDetailPage({
   params,
@@ -11,15 +15,38 @@ export default async function StrategyMatrixDetailPage({
 }) {
   const { id } = await params;
   const user = await requireAuth();
-  const matrix = await getStrategyMatrixById({ id, userId: user.id });
+  const [matrix, games, charactersByGame] = await Promise.all([
+    getStrategyMatrixById({ id, userId: user.id }),
+    getGameOptions(),
+    getAllCharactersGroupedByGame(),
+  ]);
 
   if (!matrix) notFound();
+
+  const matchupBadges = [
+    matrix.game?.name,
+    matrix.myCharacter?.name,
+    matrix.opponentCharacter?.name &&
+      `vs ${matrix.opponentCharacter.name}`,
+  ].filter(Boolean);
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-8">
       <div className="flex items-start justify-between gap-4">
-        <div>
+        <div className="space-y-2">
           <h1 className="text-3xl font-bold">{matrix.title}</h1>
+          {matchupBadges.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {matchupBadges.map((label) => (
+                <span
+                  key={label}
+                  className="bg-muted text-muted-foreground rounded-full px-2.5 py-0.5 text-xs"
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+          )}
           {matrix.description && (
             <p className="text-muted-foreground mt-1">{matrix.description}</p>
           )}
@@ -30,9 +57,14 @@ export default async function StrategyMatrixDetailPage({
       <StrategyMatrixForm
         mode="edit"
         matrixId={matrix.id}
+        games={games}
+        charactersByGame={charactersByGame}
         initialData={{
           title: matrix.title,
           description: matrix.description ?? undefined,
+          gameId: matrix.gameId ?? undefined,
+          myCharacterId: matrix.myCharacterId ?? undefined,
+          opponentCharacterId: matrix.opponentCharacterId ?? undefined,
           myAxis: matrix.myAxis,
           opponentAxis: matrix.opponentAxis,
           cells: matrix.cells,

--- a/app/(dashboard)/notes/strategy/new/page.tsx
+++ b/app/(dashboard)/notes/strategy/new/page.tsx
@@ -1,9 +1,17 @@
 import { StrategyMatrixForm } from "@/components/features/strategy-matrix/strategy-matrix-form";
 import { StrategyMatrixHelpDialog } from "@/components/features/strategy-matrix/strategy-matrix-help-dialog";
 import { requireAuth } from "@/lib/auth-utils";
+import {
+  getAllCharactersGroupedByGame,
+  getGameOptions,
+} from "../../../../../prisma/query/strategy-matrix.query";
 
 export default async function NewStrategyMatrixPage() {
   await requireAuth();
+  const [games, charactersByGame] = await Promise.all([
+    getGameOptions(),
+    getAllCharactersGroupedByGame(),
+  ]);
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-8">
@@ -18,7 +26,11 @@ export default async function NewStrategyMatrixPage() {
         <StrategyMatrixHelpDialog />
       </div>
 
-      <StrategyMatrixForm mode="create" />
+      <StrategyMatrixForm
+        mode="create"
+        games={games}
+        charactersByGame={charactersByGame}
+      />
     </div>
   );
 }

--- a/app/(dashboard)/notes/strategy/page.tsx
+++ b/app/(dashboard)/notes/strategy/page.tsx
@@ -1,13 +1,32 @@
+import { StrategyMatrixFilters } from "@/components/features/strategy-matrix/strategy-matrix-filters";
 import { StrategyMatrixList } from "@/components/features/strategy-matrix/strategy-matrix-list";
 import { Button } from "@/components/ui/button";
 import { requireAuth } from "@/lib/auth-utils";
 import { Plus } from "lucide-react";
 import Link from "next/link";
-import { getStrategyMatrices } from "../../../../prisma/query/strategy-matrix.query";
+import {
+  getAllCharactersGroupedByGame,
+  getGameOptions,
+  getStrategyMatrices,
+} from "../../../../prisma/query/strategy-matrix.query";
 
-export default async function StrategyMatrixListPage() {
+export default async function StrategyMatrixListPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ gameId?: string; characterId?: string }>;
+}) {
   const user = await requireAuth();
-  const matrices = await getStrategyMatrices({ userId: user.id });
+  const params = await searchParams;
+  const filters = {
+    gameId: params.gameId,
+    characterId: params.characterId,
+  };
+
+  const [matrices, games, charactersByGame] = await Promise.all([
+    getStrategyMatrices({ userId: user.id, filters }),
+    getGameOptions(),
+    getAllCharactersGroupedByGame(),
+  ]);
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 px-4 py-8">
@@ -25,6 +44,13 @@ export default async function StrategyMatrixListPage() {
           </Link>
         </Button>
       </div>
+
+      <StrategyMatrixFilters
+        games={games}
+        charactersByGame={charactersByGame}
+        selectedGameId={filters.gameId}
+        selectedCharacterId={filters.characterId}
+      />
 
       <StrategyMatrixList matrices={matrices} />
     </div>

--- a/prisma/migrations/20260426202441_add_strategy_matrix_matchup_context/migration.sql
+++ b/prisma/migrations/20260426202441_add_strategy_matrix_matchup_context/migration.sql
@@ -1,0 +1,19 @@
+-- AlterTable
+ALTER TABLE "StrategyMatrix" ADD COLUMN     "gameId" TEXT,
+ADD COLUMN     "myCharacterId" TEXT,
+ADD COLUMN     "opponentCharacterId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "StrategyMatrix_userId_gameId_idx" ON "StrategyMatrix"("userId", "gameId");
+
+-- CreateIndex
+CREATE INDEX "StrategyMatrix_userId_myCharacterId_opponentCharacterId_idx" ON "StrategyMatrix"("userId", "myCharacterId", "opponentCharacterId");
+
+-- AddForeignKey
+ALTER TABLE "StrategyMatrix" ADD CONSTRAINT "StrategyMatrix_gameId_fkey" FOREIGN KEY ("gameId") REFERENCES "Game"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StrategyMatrix" ADD CONSTRAINT "StrategyMatrix_myCharacterId_fkey" FOREIGN KEY ("myCharacterId") REFERENCES "Character"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StrategyMatrix" ADD CONSTRAINT "StrategyMatrix_opponentCharacterId_fkey" FOREIGN KEY ("opponentCharacterId") REFERENCES "Character"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/query/strategy-matrix.query.ts
+++ b/prisma/query/strategy-matrix.query.ts
@@ -8,9 +8,33 @@ import { prisma } from "@/lib/prisma";
 import z from "zod";
 import { Prisma } from "../../generated/prisma";
 
-export const getStrategyMatrices = async ({ userId }: { userId: string }) =>
-  await prisma.strategyMatrix.findMany({
-    where: { userId },
+type ListFilters = {
+  gameId?: string;
+  characterId?: string;
+};
+
+export const getStrategyMatrices = async ({
+  userId,
+  filters,
+}: {
+  userId: string;
+  filters?: ListFilters;
+}) => {
+  const where: Prisma.StrategyMatrixWhereInput = {
+    userId,
+    ...(filters?.gameId ? { gameId: filters.gameId } : {}),
+    ...(filters?.characterId
+      ? {
+          OR: [
+            { myCharacterId: filters.characterId },
+            { opponentCharacterId: filters.characterId },
+          ],
+        }
+      : {}),
+  };
+
+  return await prisma.strategyMatrix.findMany({
+    where,
     select: {
       id: true,
       title: true,
@@ -20,9 +44,17 @@ export const getStrategyMatrices = async ({ userId }: { userId: string }) =>
       pinned: true,
       createdAt: true,
       updatedAt: true,
+      game: { select: { id: true, name: true, slug: true, iconUrl: true } },
+      myCharacter: {
+        select: { id: true, name: true, slug: true, iconUrl: true },
+      },
+      opponentCharacter: {
+        select: { id: true, name: true, slug: true, iconUrl: true },
+      },
     },
     orderBy: [{ pinned: "desc" }, { updatedAt: "desc" }],
   });
+};
 
 export type StrategyMatrixListItem = Prisma.PromiseReturnType<
   typeof getStrategyMatrices
@@ -37,6 +69,15 @@ export const getStrategyMatrixById = async ({
 }) => {
   const matrix = await prisma.strategyMatrix.findFirst({
     where: { id, userId },
+    include: {
+      game: { select: { id: true, name: true, slug: true, iconUrl: true } },
+      myCharacter: {
+        select: { id: true, name: true, slug: true, iconUrl: true },
+      },
+      opponentCharacter: {
+        select: { id: true, name: true, slug: true, iconUrl: true },
+      },
+    },
   });
 
   if (!matrix) return null;
@@ -53,10 +94,70 @@ export const getStrategyMatrixById = async ({
     pinned: matrix.pinned,
     createdAt: matrix.createdAt,
     updatedAt: matrix.updatedAt,
+    gameId: matrix.gameId,
+    game: matrix.game,
+    myCharacterId: matrix.myCharacterId,
+    myCharacter: matrix.myCharacter,
+    opponentCharacterId: matrix.opponentCharacterId,
+    opponentCharacter: matrix.opponentCharacter,
     myAxis,
     opponentAxis,
     cells,
   };
+};
+
+export const getGameOptions = async () =>
+  await prisma.game.findMany({
+    select: { id: true, name: true, slug: true, iconUrl: true },
+    orderBy: { name: "asc" },
+  });
+
+export type GameOption = Prisma.PromiseReturnType<typeof getGameOptions>[number];
+
+export const getCharactersByGame = async ({ gameId }: { gameId: string }) =>
+  await prisma.character.findMany({
+    where: { gameId },
+    select: { id: true, name: true, slug: true, iconUrl: true },
+    orderBy: { name: "asc" },
+  });
+
+export type CharacterOption = Prisma.PromiseReturnType<
+  typeof getCharactersByGame
+>[number];
+
+export const getAllCharactersGroupedByGame = async () => {
+  const characters = await prisma.character.findMany({
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      iconUrl: true,
+      gameId: true,
+    },
+    orderBy: { name: "asc" },
+  });
+
+  const grouped: Record<string, CharacterOption[]> = {};
+  for (const char of characters) {
+    const { gameId, ...rest } = char;
+    if (!grouped[gameId]) grouped[gameId] = [];
+    grouped[gameId].push(rest);
+  }
+  return grouped;
+};
+
+export const getDistinctUserGames = async ({ userId }: { userId: string }) => {
+  const matrices = await prisma.strategyMatrix.findMany({
+    where: { userId, gameId: { not: null } },
+    select: {
+      game: { select: { id: true, name: true, slug: true, iconUrl: true } },
+    },
+    distinct: ["gameId"],
+  });
+  return matrices
+    .map((m) => m.game)
+    .filter((g): g is NonNullable<typeof g> => g !== null)
+    .sort((a, b) => a.name.localeCompare(b.name));
 };
 
 export type StrategyMatrixDetail = NonNullable<

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,29 +103,32 @@ model Tag {
 }
 
 model Game {
-  id         String      @id @default(cuid())
-  slug       String      @unique
-  name       String
-  iconUrl    String?
-  createdAt  DateTime    @default(now())
-  updatedAt  DateTime    @updatedAt
-  characters Character[]
-  combos     Combo[]
+  id               String           @id @default(cuid())
+  slug             String           @unique
+  name             String
+  iconUrl          String?
+  createdAt        DateTime         @default(now())
+  updatedAt        DateTime         @updatedAt
+  characters       Character[]
+  combos           Combo[]
+  strategyMatrices StrategyMatrix[]
 
   @@index([slug])
 }
 
 model Character {
-  id        String   @id @default(cuid())
-  gameId    String
-  game      Game     @relation(fields: [gameId], references: [id], onDelete: Cascade)
-  slug      String
-  name      String
-  iconUrl   String?
-  notes     Note[]
-  combos    Combo[]
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id                       String           @id @default(cuid())
+  gameId                   String
+  game                     Game             @relation(fields: [gameId], references: [id], onDelete: Cascade)
+  slug                     String
+  name                     String
+  iconUrl                  String?
+  notes                    Note[]
+  combos                   Combo[]
+  myStrategyMatrices       StrategyMatrix[] @relation("MyCharacterMatrices")
+  opponentStrategyMatrices StrategyMatrix[] @relation("OpponentCharacterMatrices")
+  createdAt                DateTime         @default(now())
+  updatedAt                DateTime         @updatedAt
 
   @@unique([gameId, slug])
   @@index([gameId])
@@ -157,19 +160,27 @@ model Combo {
 }
 
 model StrategyMatrix {
-  id           String   @id @default(cuid())
-  userId       String
-  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  title        String
-  description  String?
-  myAxis       Json
-  opponentAxis Json
-  cells        Json
-  pinned       Boolean  @default(false)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id                  String     @id @default(cuid())
+  userId              String
+  user                User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  title               String
+  description         String?
+  gameId              String?
+  game                Game?      @relation(fields: [gameId], references: [id], onDelete: SetNull)
+  myCharacterId       String?
+  myCharacter         Character? @relation("MyCharacterMatrices", fields: [myCharacterId], references: [id], onDelete: SetNull)
+  opponentCharacterId String?
+  opponentCharacter   Character? @relation("OpponentCharacterMatrices", fields: [opponentCharacterId], references: [id], onDelete: SetNull)
+  myAxis              Json
+  opponentAxis        Json
+  cells               Json
+  pinned              Boolean    @default(false)
+  createdAt           DateTime   @default(now())
+  updatedAt           DateTime   @updatedAt
 
   @@index([userId])
+  @@index([userId, gameId])
+  @@index([userId, myCharacterId, opponentCharacterId])
 }
 
 model GlossaryArticle {

--- a/src/components/features/strategy-matrix/strategy-matrix-action.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-action.ts
@@ -18,6 +18,9 @@ export const createStrategyMatrixAction = authActionClient
         userId: ctx.user.id,
         title: parsedInput.title,
         description: parsedInput.description,
+        gameId: parsedInput.gameId ?? null,
+        myCharacterId: parsedInput.myCharacterId ?? null,
+        opponentCharacterId: parsedInput.opponentCharacterId ?? null,
         myAxis: parsedInput.myAxis as unknown as Prisma.InputJsonValue,
         opponentAxis:
           parsedInput.opponentAxis as unknown as Prisma.InputJsonValue,
@@ -46,6 +49,9 @@ export const updateStrategyMatrixAction = authActionClient
       data: {
         title: parsedInput.title,
         description: parsedInput.description,
+        gameId: parsedInput.gameId ?? null,
+        myCharacterId: parsedInput.myCharacterId ?? null,
+        opponentCharacterId: parsedInput.opponentCharacterId ?? null,
         myAxis: parsedInput.myAxis as unknown as Prisma.InputJsonValue,
         opponentAxis:
           parsedInput.opponentAxis as unknown as Prisma.InputJsonValue,

--- a/src/components/features/strategy-matrix/strategy-matrix-ai-action.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-ai-action.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import { generateStrategyMatrixCells } from "@/lib/ai/groq";
+import { authActionClient } from "@/lib/auth-action";
+import { prisma } from "@/lib/prisma";
+import z from "zod";
+import { axisSchema } from "./strategy-matrix-schema";
+
+export const fillStrategyMatrixWithAiAction = authActionClient
+  .inputSchema(
+    z.object({
+      title: z.string().min(1).max(120),
+      description: z.string().max(500).optional(),
+      gameId: z.string().min(1).optional(),
+      myCharacterId: z.string().min(1).optional(),
+      opponentCharacterId: z.string().min(1).optional(),
+      myAxis: axisSchema,
+      opponentAxis: axisSchema,
+    }),
+  )
+  .action(async ({ parsedInput }) => {
+    const [game, myChar, oppChar] = await Promise.all([
+      parsedInput.gameId
+        ? prisma.game.findUnique({
+            where: { id: parsedInput.gameId },
+            select: { name: true },
+          })
+        : null,
+      parsedInput.myCharacterId
+        ? prisma.character.findUnique({
+            where: { id: parsedInput.myCharacterId },
+            select: { name: true },
+          })
+        : null,
+      parsedInput.opponentCharacterId
+        ? prisma.character.findUnique({
+            where: { id: parsedInput.opponentCharacterId },
+            select: { name: true },
+          })
+        : null,
+    ]);
+
+    const cells = await generateStrategyMatrixCells({
+      title: parsedInput.title,
+      description: parsedInput.description,
+      gameName: game?.name,
+      myCharacterName: myChar?.name,
+      opponentCharacterName: oppChar?.name,
+      myAxis: parsedInput.myAxis,
+      opponentAxis: parsedInput.opponentAxis,
+    });
+
+    if (!cells) {
+      throw new Error(
+        "Erreur lors de la génération IA. Vérifiez la clé API Groq.",
+      );
+    }
+
+    return { cells };
+  });

--- a/src/components/features/strategy-matrix/strategy-matrix-ai-fill-button.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-ai-fill-button.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Loader2, Sparkles } from "lucide-react";
+import { useAction } from "next-safe-action/hooks";
+import { useState } from "react";
+import { toast } from "sonner";
+import { fillStrategyMatrixWithAiAction } from "./strategy-matrix-ai-action";
+import type { Axis, Cell } from "./strategy-matrix-schema";
+
+type Props = {
+  title: string;
+  description?: string;
+  gameId?: string;
+  myCharacterId?: string;
+  opponentCharacterId?: string;
+  myAxis: Axis;
+  opponentAxis: Axis;
+  cells: Cell[];
+  onCellsGenerated: (cells: Cell[]) => void;
+};
+
+export function StrategyMatrixAiFillButton({
+  title,
+  description,
+  gameId,
+  myCharacterId,
+  opponentCharacterId,
+  myAxis,
+  opponentAxis,
+  cells,
+  onCellsGenerated,
+}: Props) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const { execute, isPending } = useAction(fillStrategyMatrixWithAiAction, {
+    onSuccess: ({ data }) => {
+      if (!data?.cells || data.cells.length === 0) {
+        toast.error("Aucune cellule générée");
+        return;
+      }
+      onCellsGenerated(data.cells);
+      toast.success(`${data.cells.length} cellules remplies par l'IA`);
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? "Erreur lors de la génération");
+    },
+  });
+
+  const hasContent = cells.some((c) => c.content.trim().length > 0);
+  const hasTitle = title.trim().length > 0;
+
+  const triggerFill = () => {
+    execute({
+      title,
+      description,
+      gameId,
+      myCharacterId,
+      opponentCharacterId,
+      myAxis,
+      opponentAxis,
+    });
+  };
+
+  const handleClick = () => {
+    if (hasContent) {
+      setConfirmOpen(true);
+      return;
+    }
+    triggerFill();
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleClick}
+        disabled={isPending || !hasTitle}
+      >
+        {isPending ? (
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        ) : (
+          <Sparkles className="mr-2 h-4 w-4" />
+        )}
+        {isPending ? "Génération…" : "Remplir avec IA"}
+      </Button>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Écraser le contenu existant ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Certaines cellules contiennent déjà du contenu. La génération IA
+              remplacera tout le contenu existant. Vous pourrez encore éditer
+              chaque cellule manuellement après.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setConfirmOpen(false);
+                triggerFill();
+              }}
+            >
+              Continuer
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/features/strategy-matrix/strategy-matrix-filters.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-filters.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useRouter, useSearchParams } from "next/navigation";
+import type {
+  CharacterOption,
+  GameOption,
+} from "../../../../prisma/query/strategy-matrix.query";
+
+const ALL_VALUE = "__all__";
+
+type Props = {
+  games: GameOption[];
+  charactersByGame: Record<string, CharacterOption[]>;
+  selectedGameId?: string;
+  selectedCharacterId?: string;
+};
+
+export function StrategyMatrixFilters({
+  games,
+  charactersByGame,
+  selectedGameId,
+  selectedCharacterId,
+}: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const characters = selectedGameId
+    ? (charactersByGame[selectedGameId] ?? [])
+    : [];
+
+  const updateParams = (next: {
+    gameId?: string;
+    characterId?: string;
+  }) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next.gameId) params.set("gameId", next.gameId);
+    else params.delete("gameId");
+    if (next.characterId) params.set("characterId", next.characterId);
+    else params.delete("characterId");
+    const qs = params.toString();
+    router.push(`/notes/strategy${qs ? `?${qs}` : ""}`);
+  };
+
+  const handleGameChange = (raw: string) => {
+    updateParams({
+      gameId: raw === ALL_VALUE ? undefined : raw,
+      characterId: undefined,
+    });
+  };
+
+  const handleCharacterChange = (raw: string) => {
+    updateParams({
+      gameId: selectedGameId,
+      characterId: raw === ALL_VALUE ? undefined : raw,
+    });
+  };
+
+  const hasFilter = Boolean(selectedGameId || selectedCharacterId);
+
+  return (
+    <div className="flex flex-wrap items-end gap-3">
+      <div className="space-y-1">
+        <label className="text-xs font-medium">Jeu</label>
+        <Select
+          value={selectedGameId ?? ALL_VALUE}
+          onValueChange={handleGameChange}
+        >
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="Tous" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_VALUE}>Tous les jeux</SelectItem>
+            {games.map((g) => (
+              <SelectItem key={g.id} value={g.id}>
+                {g.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1">
+        <label className="text-xs font-medium">Personnage</label>
+        <Select
+          value={selectedCharacterId ?? ALL_VALUE}
+          onValueChange={handleCharacterChange}
+          disabled={!selectedGameId || characters.length === 0}
+        >
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="Tous" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_VALUE}>Tous les personnages</SelectItem>
+            {characters.map((c) => (
+              <SelectItem key={c.id} value={c.id}>
+                {c.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {hasFilter && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => updateParams({})}
+        >
+          Réinitialiser
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/strategy-matrix/strategy-matrix-form.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-form.tsx
@@ -18,6 +18,10 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
+import type {
+  CharacterOption,
+  GameOption,
+} from "../../../../prisma/query/strategy-matrix.query";
 import {
   createStrategyMatrixAction,
   updateStrategyMatrixAction,
@@ -25,6 +29,7 @@ import {
 import { StrategyMatrixAxisBuilder } from "./strategy-matrix-axis-builder";
 import { StrategyMatrixCellEditor } from "./strategy-matrix-cell-editor";
 import { StrategyMatrixGrid } from "./strategy-matrix-grid";
+import { StrategyMatrixMatchupSelector } from "./strategy-matrix-matchup-selector";
 import {
   strategyMatrixCreateSchema,
   type Axis,
@@ -41,19 +46,26 @@ import {
   reconcileCells,
 } from "./strategy-matrix-types";
 
-type Props =
-  | {
-      mode: "create";
-      initialTemplate?: StrategyMatrixTemplate;
-      matrixId?: undefined;
-      initialData?: undefined;
-    }
-  | {
-      mode: "edit";
-      matrixId: string;
-      initialData: StrategyMatrixCreateInput;
-      initialTemplate?: undefined;
-    };
+type CommonProps = {
+  games: GameOption[];
+  charactersByGame: Record<string, CharacterOption[]>;
+};
+
+type Props = CommonProps &
+  (
+    | {
+        mode: "create";
+        initialTemplate?: StrategyMatrixTemplate;
+        matrixId?: undefined;
+        initialData?: undefined;
+      }
+    | {
+        mode: "edit";
+        matrixId: string;
+        initialData: StrategyMatrixCreateInput;
+        initialTemplate?: undefined;
+      }
+  );
 
 type EditingCell = {
   myLevelId: string;
@@ -69,6 +81,9 @@ export function StrategyMatrixForm(props: Props) {
       : {
           title: fallback.title,
           description: undefined,
+          gameId: undefined,
+          myCharacterId: undefined,
+          opponentCharacterId: undefined,
           myAxis: fallback.myAxis,
           opponentAxis: fallback.opponentAxis,
           cells: fallback.cells,
@@ -86,6 +101,9 @@ export function StrategyMatrixForm(props: Props) {
   const myAxis = form.watch("myAxis");
   const opponentAxis = form.watch("opponentAxis");
   const cells = form.watch("cells");
+  const gameId = form.watch("gameId");
+  const myCharacterId = form.watch("myCharacterId");
+  const opponentCharacterId = form.watch("opponentCharacterId");
 
   const createAction = useAction(createStrategyMatrixAction, {
     onSuccess: ({ data }) => {
@@ -113,11 +131,26 @@ export function StrategyMatrixForm(props: Props) {
     form.reset({
       title: template.title,
       description: undefined,
+      gameId,
+      myCharacterId,
+      opponentCharacterId,
       myAxis: template.myAxis,
       opponentAxis: template.opponentAxis,
       cells: template.cells,
     });
     setShowTemplatePicker(false);
+  };
+
+  const handleMatchupChange = (next: {
+    gameId?: string;
+    myCharacterId?: string;
+    opponentCharacterId?: string;
+  }) => {
+    form.setValue("gameId", next.gameId, { shouldDirty: true });
+    form.setValue("myCharacterId", next.myCharacterId, { shouldDirty: true });
+    form.setValue("opponentCharacterId", next.opponentCharacterId, {
+      shouldDirty: true,
+    });
   };
 
   const handleAxisChange = (
@@ -222,6 +255,13 @@ export function StrategyMatrixForm(props: Props) {
               <FormMessage />
             </FormItem>
           )}
+        />
+
+        <StrategyMatrixMatchupSelector
+          games={props.games}
+          charactersByGame={props.charactersByGame}
+          value={{ gameId, myCharacterId, opponentCharacterId }}
+          onChange={handleMatchupChange}
         />
 
         <div className="grid gap-4 md:grid-cols-2">

--- a/src/components/features/strategy-matrix/strategy-matrix-form.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-form.tsx
@@ -26,6 +26,7 @@ import {
   createStrategyMatrixAction,
   updateStrategyMatrixAction,
 } from "./strategy-matrix-action";
+import { StrategyMatrixAiFillButton } from "./strategy-matrix-ai-fill-button";
 import { StrategyMatrixAxisBuilder } from "./strategy-matrix-axis-builder";
 import { StrategyMatrixCellEditor } from "./strategy-matrix-cell-editor";
 import { StrategyMatrixGrid } from "./strategy-matrix-grid";
@@ -176,6 +177,16 @@ export function StrategyMatrixForm(props: Props) {
     form.setValue("cells", Array.from(lookup.values()), { shouldDirty: true });
   };
 
+  const handleAiCellsGenerated = (
+    generated: { myLevelId: string; opponentLevelId: string; content: string }[],
+  ) => {
+    const lookup = buildCellLookup(form.getValues("cells"));
+    for (const cell of generated) {
+      lookup.set(cellKey(cell.myLevelId, cell.opponentLevelId), cell);
+    }
+    form.setValue("cells", Array.from(lookup.values()), { shouldDirty: true });
+  };
+
   const onSubmit = (data: StrategyMatrixCreateInput) => {
     const reconciled = reconcileCells(
       data.cells,
@@ -278,7 +289,20 @@ export function StrategyMatrixForm(props: Props) {
         </div>
 
         <div className="space-y-2">
-          <FormLabel>Matrice</FormLabel>
+          <div className="flex items-center justify-between gap-2">
+            <FormLabel>Matrice</FormLabel>
+            <StrategyMatrixAiFillButton
+              title={form.watch("title")}
+              description={form.watch("description")}
+              gameId={gameId}
+              myCharacterId={myCharacterId}
+              opponentCharacterId={opponentCharacterId}
+              myAxis={myAxis}
+              opponentAxis={opponentAxis}
+              cells={cells}
+              onCellsGenerated={handleAiCellsGenerated}
+            />
+          </div>
           <FormDescription>
             Cliquez sur une cellule pour éditer son contenu en markdown.
           </FormDescription>

--- a/src/components/features/strategy-matrix/strategy-matrix-list.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-list.tsx
@@ -55,10 +55,30 @@ export function StrategyMatrixList({ matrices }: Props) {
 
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {matrices.map((matrix) => (
+      {matrices.map((matrix) => {
+        const matchupBadges = [
+          matrix.game?.name,
+          matrix.myCharacter?.name,
+          matrix.opponentCharacter?.name &&
+            `vs ${matrix.opponentCharacter.name}`,
+        ].filter(Boolean) as string[];
+
+        return (
         <Card key={matrix.id} className="flex flex-col gap-3 p-4">
           <div className="space-y-1">
             <h3 className="line-clamp-1 font-semibold">{matrix.title}</h3>
+            {matchupBadges.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {matchupBadges.map((label) => (
+                  <span
+                    key={label}
+                    className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-[10px]"
+                  >
+                    {label}
+                  </span>
+                ))}
+              </div>
+            )}
             {matrix.description && (
               <p className="text-muted-foreground line-clamp-2 text-sm">
                 {matrix.description}
@@ -97,7 +117,8 @@ export function StrategyMatrixList({ matrices }: Props) {
             </AlertDialog>
           </div>
         </Card>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/src/components/features/strategy-matrix/strategy-matrix-matchup-selector.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-matchup-selector.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  CharacterOption,
+  GameOption,
+} from "../../../../prisma/query/strategy-matrix.query";
+
+const NONE_VALUE = "__none__";
+
+type MatchupValue = {
+  gameId?: string;
+  myCharacterId?: string;
+  opponentCharacterId?: string;
+};
+
+type Props = {
+  games: GameOption[];
+  charactersByGame: Record<string, CharacterOption[]>;
+  value: MatchupValue;
+  onChange: (next: MatchupValue) => void;
+};
+
+export function StrategyMatrixMatchupSelector({
+  games,
+  charactersByGame,
+  value,
+  onChange,
+}: Props) {
+  const characters = value.gameId
+    ? (charactersByGame[value.gameId] ?? [])
+    : [];
+
+  const handleGameChange = (raw: string) => {
+    const gameId = raw === NONE_VALUE ? undefined : raw;
+    onChange({
+      gameId,
+      myCharacterId: undefined,
+      opponentCharacterId: undefined,
+    });
+  };
+
+  const handleCharacterChange = (
+    field: "myCharacterId" | "opponentCharacterId",
+    raw: string,
+  ) => {
+    onChange({
+      ...value,
+      [field]: raw === NONE_VALUE ? undefined : raw,
+    });
+  };
+
+  return (
+    <div className="space-y-3 rounded-md border p-4">
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold">Contexte matchup (optionnel)</h3>
+        <p className="text-muted-foreground text-xs">
+          Associez cette matrice à un jeu et à des personnages pour pouvoir la
+          retrouver par matchup.
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="space-y-1">
+          <label className="text-xs font-medium">Jeu</label>
+          <Select
+            value={value.gameId ?? NONE_VALUE}
+            onValueChange={handleGameChange}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Aucun" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NONE_VALUE}>Aucun</SelectItem>
+              {games.map((g) => (
+                <SelectItem key={g.id} value={g.id}>
+                  {g.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-xs font-medium">Mon personnage</label>
+          <Select
+            value={value.myCharacterId ?? NONE_VALUE}
+            onValueChange={(v) => handleCharacterChange("myCharacterId", v)}
+            disabled={!value.gameId || characters.length === 0}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Aucun" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NONE_VALUE}>Aucun</SelectItem>
+              {characters.map((c) => (
+                <SelectItem key={c.id} value={c.id}>
+                  {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-xs font-medium">Personnage adverse</label>
+          <Select
+            value={value.opponentCharacterId ?? NONE_VALUE}
+            onValueChange={(v) =>
+              handleCharacterChange("opponentCharacterId", v)
+            }
+            disabled={!value.gameId || characters.length === 0}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Aucun" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NONE_VALUE}>Aucun</SelectItem>
+              {characters.map((c) => (
+                <SelectItem key={c.id} value={c.id}>
+                  {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/strategy-matrix/strategy-matrix-schema.test.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-schema.test.ts
@@ -112,4 +112,38 @@ describe("strategyMatrixCreateSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("accepts gameId + characterIds together", () => {
+    const result = strategyMatrixCreateSchema.safeParse({
+      title: baseTemplate.title,
+      gameId: "game-1",
+      myCharacterId: "char-1",
+      opponentCharacterId: "char-2",
+      myAxis: baseTemplate.myAxis,
+      opponentAxis: baseTemplate.opponentAxis,
+      cells: baseTemplate.cells,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects characterId without gameId", () => {
+    const result = strategyMatrixCreateSchema.safeParse({
+      title: baseTemplate.title,
+      myCharacterId: "char-1",
+      myAxis: baseTemplate.myAxis,
+      opponentAxis: baseTemplate.opponentAxis,
+      cells: baseTemplate.cells,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts no matchup context (V1 backward compat)", () => {
+    const result = strategyMatrixCreateSchema.safeParse({
+      title: baseTemplate.title,
+      myAxis: baseTemplate.myAxis,
+      opponentAxis: baseTemplate.opponentAxis,
+      cells: baseTemplate.cells,
+    });
+    expect(result.success).toBe(true);
+  });
 });

--- a/src/components/features/strategy-matrix/strategy-matrix-schema.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-schema.ts
@@ -52,6 +52,9 @@ const matrixBaseSchema = z
       .string()
       .max(500, { error: "Maximum 500 caractères" })
       .optional(),
+    gameId: z.string().min(1).optional(),
+    myCharacterId: z.string().min(1).optional(),
+    opponentCharacterId: z.string().min(1).optional(),
     myAxis: axisSchema,
     opponentAxis: axisSchema,
     cells: z.array(cellSchema),
@@ -65,6 +68,14 @@ const matrixBaseSchema = z
       );
     },
     { error: "Cellules orphelines détectées" },
+  )
+  .refine(
+    (data) => {
+      if (data.myCharacterId && !data.gameId) return false;
+      if (data.opponentCharacterId && !data.gameId) return false;
+      return true;
+    },
+    { error: "Un jeu doit être sélectionné pour associer un personnage" },
   );
 
 export const strategyMatrixCreateSchema = matrixBaseSchema;

--- a/src/lib/ai/groq.ts
+++ b/src/lib/ai/groq.ts
@@ -70,6 +70,114 @@ export async function suggestTagsFromNote(
   }
 }
 
+export type MatrixAxisInput = {
+  label: string;
+  resource: string;
+  levels: Array<{ id: string; label: string }>;
+};
+
+export type MatrixCellOutput = {
+  myLevelId: string;
+  opponentLevelId: string;
+  content: string;
+};
+
+const matrixCellsSchema = z.object({
+  cells: z.array(
+    z.object({
+      myLevelId: z.string(),
+      opponentLevelId: z.string(),
+      content: z.string().max(2000),
+    }),
+  ),
+});
+
+export async function generateStrategyMatrixCells(input: {
+  title: string;
+  description?: string;
+  gameName?: string;
+  myCharacterName?: string;
+  opponentCharacterName?: string;
+  myAxis: MatrixAxisInput;
+  opponentAxis: MatrixAxisInput;
+}): Promise<MatrixCellOutput[] | null> {
+  if (!groqClient) {
+    return null;
+  }
+
+  const matchupContext = [
+    input.gameName && `Jeu : ${input.gameName}`,
+    input.myCharacterName && `Mon perso : ${input.myCharacterName}`,
+    input.opponentCharacterName && `Adversaire : ${input.opponentCharacterName}`,
+  ]
+    .filter(Boolean)
+    .join(" | ");
+
+  const myLevels = input.myAxis.levels
+    .map((l) => `${l.id} (${l.label})`)
+    .join(", ");
+  const oppLevels = input.opponentAxis.levels
+    .map((l) => `${l.id} (${l.label})`)
+    .join(", ");
+
+  try {
+    const response = await groqClient.chat.completions.create({
+      model: "llama-3.3-70b-versatile",
+      messages: [
+        {
+          role: "system",
+          content: `Tu es un coach de jeux de combat (FGC) expert en stratégie conditionnelle. On te fournit une matrice de décision croisant l'état d'un joueur (colonnes) et l'état adverse (lignes). Tu dois remplir CHAQUE cellule avec l'action optimale.
+
+Réponds STRICTEMENT en JSON :
+{
+  "cells": [
+    { "myLevelId": "<id>", "opponentLevelId": "<id>", "content": "<stratégie markdown>" }
+  ]
+}
+
+Règles :
+- Une cellule par combinaison myLevelId × opponentLevelId (toutes les combinaisons)
+- Utilise EXACTEMENT les ids fournis (pas de nouveaux ids)
+- Chaque "content" : stratégie concrète et actionnable, 2-4 lignes max, vocabulaire FGC (frame trap, whiff punish, oki, mixup, hit confirm, DI, drive rush, etc.)
+- Markdown supporté (**gras**, listes, →)
+- Maximum 500 caractères par cellule
+- Réponds en français`,
+        },
+        {
+          role: "user",
+          content: `Matrice : "${input.title}"${input.description ? `\nDescription : ${input.description}` : ""}${matchupContext ? `\nContexte : ${matchupContext}` : ""}
+
+Axe COLONNES (mes états) — label "${input.myAxis.label}" (${input.myAxis.resource})
+Niveaux : ${myLevels}
+
+Axe LIGNES (état adverse) — label "${input.opponentAxis.label}" (${input.opponentAxis.resource})
+Niveaux : ${oppLevels}
+
+Génère ${input.myAxis.levels.length * input.opponentAxis.levels.length} cellules, une pour chaque combinaison.`,
+        },
+      ],
+      response_format: { type: "json_object" },
+      temperature: 0.5,
+      max_tokens: 3000,
+    });
+
+    const content = response.choices[0]?.message?.content;
+    if (!content) {
+      return null;
+    }
+
+    const parsed = matrixCellsSchema.parse(JSON.parse(content));
+    const myIds = new Set(input.myAxis.levels.map((l) => l.id));
+    const oppIds = new Set(input.opponentAxis.levels.map((l) => l.id));
+
+    return parsed.cells.filter(
+      (c) => myIds.has(c.myLevelId) && oppIds.has(c.opponentLevelId),
+    );
+  } catch {
+    return null;
+  }
+}
+
 export async function generateMatchReport(
   notes: Array<{ timestamp: number; content: string; tags: string[] }>,
   matchTitle: string,


### PR DESCRIPTION
## Summary

Strategy Matrix V3 (lite) — adds AI-powered cell pre-filling using Groq (llama-3.3-70b-versatile). Generates contextual strategies for each level combination based on matchup context (game + characters from V2) and axis definitions.

- Add `generateStrategyMatrixCells()` in `src/lib/ai/groq.ts`
- Add `fillStrategyMatrixWithAiAction` server action
- Add AI fill button component with overwrite confirmation
- Inject matchup metadata into Groq system prompt for FGC relevance
- Validate AI output: filter cells with unknown level ids
- Loading state + toast feedback (success/error)

## How it works

1. User defines axes (HP × Meter, Drive × Position, etc.)
2. Optionally selects matchup (Ken vs Juri)
3. Clicks "Remplir avec IA" → Groq generates one cell per combination
4. If cells already have content, AlertDialog warns about overwrite
5. User reviews and edits the AI suggestions before saving

## Why "lite"

Original V3 spec included multi-axis (3D matrices) + resource metadata + per-game templates. We chose to ship IA fill first (highest ROI per brainstorm doc Top #3) before adding multi-axis complexity. Users validate IA before we build 3D UI.

## Testing

- ✓ TypeScript strict mode
- ✓ ESLint (no warnings)
- ✓ 75 tests passing
- ✓ Manual test required: needs `GROQ_API_KEY` env var

## Base Branch

Targets `feat/strategy-matrix-v2` (PR #43). Will rebase onto main once V2 is merged.

## Files

5 files changed (+322, -1)
- 2 new components (ai-action, ai-fill-button)
- Updated: groq.ts, strategy-matrix-form.tsx, CHANGELOG.md