### PR TITLE
feat(character-combo): admin characters CRUD (phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## 2026-05-02
 
+### Added: Admin management for characters (CRUD)
+
+### Refactor: Extract generateSlug util to src/lib/slug.ts
+
+### Refactor: Migrate Character queries from strategy-matrix to dedicated character.query.ts
+
 ### Added: Cell editor quick insert — selects notation FGC et frame data avec rendu coloré dans le preview
 
 ### Added: Dashboard — liste des dernières matrices de stratégie de l'utilisateur sous forme de cards

--- a/app/(dashboard)/admin/characters/[id]/edit/page.tsx
+++ b/app/(dashboard)/admin/characters/[id]/edit/page.tsx
@@ -1,0 +1,31 @@
+import { requireAdmin } from "@/lib/auth-utils";
+import { getCharacterByIdForAdmin } from "@/../prisma/query/admin-character.query";
+import { getGameOptions } from "@/../prisma/query/game.query";
+import { CharacterForm } from "@/components/features/admin/character/character-form";
+import { notFound } from "next/navigation";
+
+interface EditCharacterPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function EditCharacterPage({
+  params,
+}: EditCharacterPageProps) {
+  await requireAdmin();
+  const { id } = await params;
+  const [character, games] = await Promise.all([
+    getCharacterByIdForAdmin(id),
+    getGameOptions(),
+  ]);
+
+  if (!character) {
+    notFound();
+  }
+
+  return (
+    <div className="container mx-auto max-w-7xl px-4 py-8">
+      <h1 className="mb-6 text-3xl font-bold">Modifier le personnage</h1>
+      <CharacterForm mode="edit" character={character} games={games} />
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/characters/new/page.tsx
+++ b/app/(dashboard)/admin/characters/new/page.tsx
@@ -1,0 +1,15 @@
+import { requireAdmin } from "@/lib/auth-utils";
+import { getGameOptions } from "@/../prisma/query/game.query";
+import { CharacterForm } from "@/components/features/admin/character/character-form";
+
+export default async function NewCharacterPage() {
+  await requireAdmin();
+  const games = await getGameOptions();
+
+  return (
+    <div className="container mx-auto max-w-7xl px-4 py-8">
+      <h1 className="mb-6 text-3xl font-bold">Créer un nouveau personnage</h1>
+      <CharacterForm mode="create" games={games} />
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/characters/page.tsx
+++ b/app/(dashboard)/admin/characters/page.tsx
@@ -1,0 +1,31 @@
+import { requireAdmin } from "@/lib/auth-utils";
+import { getAllCharactersForAdmin } from "@/../prisma/query/admin-character.query";
+import { CharacterList } from "@/components/features/admin/character/character-list";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { Plus } from "lucide-react";
+
+export default async function AdminCharactersPage() {
+  await requireAdmin();
+  const characters = await getAllCharactersForAdmin();
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Gestion des personnages</h1>
+          <p className="text-muted-foreground mt-1">
+            {characters.length} personnage{characters.length > 1 ? "s" : ""}
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/admin/characters/new">
+            <Plus className="mr-2 h-4 w-4" />
+            Créer un personnage
+          </Link>
+        </Button>
+      </div>
+      <CharacterList characters={characters} />
+    </div>
+  );
+}

--- a/prisma/query/admin-character.query.ts
+++ b/prisma/query/admin-character.query.ts
@@ -1,0 +1,58 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "../../generated/prisma";
+
+export const getAllCharactersForAdmin = async () =>
+  await prisma.character.findMany({
+    select: {
+      id: true,
+      slug: true,
+      name: true,
+      iconUrl: true,
+      createdAt: true,
+      updatedAt: true,
+      game: {
+        select: {
+          id: true,
+          slug: true,
+          name: true,
+          iconUrl: true,
+        },
+      },
+      _count: {
+        select: {
+          combos: true,
+          notes: true,
+        },
+      },
+    },
+    orderBy: [{ game: { name: "asc" } }, { name: "asc" }],
+  });
+
+export const getCharacterByIdForAdmin = async (id: string) =>
+  await prisma.character.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      slug: true,
+      name: true,
+      iconUrl: true,
+      gameId: true,
+      createdAt: true,
+      updatedAt: true,
+      game: {
+        select: {
+          id: true,
+          slug: true,
+          name: true,
+          iconUrl: true,
+        },
+      },
+    },
+  });
+
+export type AdminCharacterList = Prisma.PromiseReturnType<
+  typeof getAllCharactersForAdmin
+>;
+export type AdminCharacterDetail = Prisma.PromiseReturnType<
+  typeof getCharacterByIdForAdmin
+>;

--- a/prisma/query/character.query.ts
+++ b/prisma/query/character.query.ts
@@ -1,0 +1,34 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "../../generated/prisma";
+
+export const getCharactersByGame = async ({ gameId }: { gameId: string }) =>
+  await prisma.character.findMany({
+    where: { gameId },
+    select: { id: true, name: true, slug: true, iconUrl: true },
+    orderBy: { name: "asc" },
+  });
+
+export type CharacterOption = Prisma.PromiseReturnType<
+  typeof getCharactersByGame
+>[number];
+
+export const getAllCharactersGroupedByGame = async () => {
+  const characters = await prisma.character.findMany({
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      iconUrl: true,
+      gameId: true,
+    },
+    orderBy: { name: "asc" },
+  });
+
+  const grouped: Record<string, CharacterOption[]> = {};
+  for (const char of characters) {
+    const { gameId, ...rest } = char;
+    if (!grouped[gameId]) grouped[gameId] = [];
+    grouped[gameId].push(rest);
+  }
+  return grouped;
+};

--- a/prisma/query/game.query.ts
+++ b/prisma/query/game.query.ts
@@ -13,3 +13,11 @@ export const getAllGames = async () =>
   });
 
 export type GameList = Prisma.PromiseReturnType<typeof getAllGames>;
+
+export const getGameOptions = async () =>
+  await prisma.game.findMany({
+    select: { id: true, name: true, slug: true, iconUrl: true },
+    orderBy: { name: "asc" },
+  });
+
+export type GameOption = Prisma.PromiseReturnType<typeof getGameOptions>[number];

--- a/prisma/query/strategy-matrix.query.ts
+++ b/prisma/query/strategy-matrix.query.ts
@@ -143,45 +143,12 @@ export const getStrategyMatrixById = async ({
   };
 };
 
-export const getGameOptions = async () =>
-  await prisma.game.findMany({
-    select: { id: true, name: true, slug: true, iconUrl: true },
-    orderBy: { name: "asc" },
-  });
-
-export type GameOption = Prisma.PromiseReturnType<typeof getGameOptions>[number];
-
-export const getCharactersByGame = async ({ gameId }: { gameId: string }) =>
-  await prisma.character.findMany({
-    where: { gameId },
-    select: { id: true, name: true, slug: true, iconUrl: true },
-    orderBy: { name: "asc" },
-  });
-
-export type CharacterOption = Prisma.PromiseReturnType<
-  typeof getCharactersByGame
->[number];
-
-export const getAllCharactersGroupedByGame = async () => {
-  const characters = await prisma.character.findMany({
-    select: {
-      id: true,
-      name: true,
-      slug: true,
-      iconUrl: true,
-      gameId: true,
-    },
-    orderBy: { name: "asc" },
-  });
-
-  const grouped: Record<string, CharacterOption[]> = {};
-  for (const char of characters) {
-    const { gameId, ...rest } = char;
-    if (!grouped[gameId]) grouped[gameId] = [];
-    grouped[gameId].push(rest);
-  }
-  return grouped;
-};
+export { getGameOptions, type GameOption } from "./game.query";
+export {
+  getCharactersByGame,
+  getAllCharactersGroupedByGame,
+  type CharacterOption,
+} from "./character.query";
 
 export const getDistinctUserGames = async ({ userId }: { userId: string }) => {
   const matrices = await prisma.strategyMatrix.findMany({

--- a/src/components/features/admin/character/character-action.ts
+++ b/src/components/features/admin/character/character-action.ts
@@ -1,0 +1,102 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { adminActionClient } from "@/lib/admin-action";
+import { revalidatePath } from "next/cache";
+import {
+  createCharacterSchema,
+  updateCharacterSchema,
+} from "./character-schema";
+import z from "zod";
+
+export const createCharacterAction = adminActionClient
+  .inputSchema(createCharacterSchema)
+  .action(async ({ parsedInput }) => {
+    const { gameId, name, slug, iconUrl } = parsedInput;
+
+    const game = await prisma.game.findUnique({ where: { id: gameId } });
+    if (!game) {
+      throw new Error("Le jeu sélectionné est introuvable");
+    }
+
+    const existing = await prisma.character.findFirst({
+      where: { gameId, slug },
+    });
+
+    if (existing) {
+      throw new Error(
+        "Un personnage avec ce slug existe déjà pour ce jeu",
+      );
+    }
+
+    const character = await prisma.character.create({
+      data: {
+        gameId,
+        name,
+        slug,
+        iconUrl: iconUrl && iconUrl.length > 0 ? iconUrl : null,
+      },
+    });
+
+    revalidatePath("/admin/characters");
+    revalidatePath("/admin/games");
+
+    return character;
+  });
+
+export const updateCharacterAction = adminActionClient
+  .inputSchema(updateCharacterSchema)
+  .action(async ({ parsedInput }) => {
+    const { id, gameId, name, slug, iconUrl } = parsedInput;
+
+    const game = await prisma.game.findUnique({ where: { id: gameId } });
+    if (!game) {
+      throw new Error("Le jeu sélectionné est introuvable");
+    }
+
+    const existing = await prisma.character.findFirst({
+      where: {
+        gameId,
+        slug,
+        NOT: { id },
+      },
+    });
+
+    if (existing) {
+      throw new Error(
+        "Un personnage avec ce slug existe déjà pour ce jeu",
+      );
+    }
+
+    const character = await prisma.character.update({
+      where: { id },
+      data: {
+        gameId,
+        name,
+        slug,
+        iconUrl: iconUrl && iconUrl.length > 0 ? iconUrl : null,
+      },
+    });
+
+    revalidatePath("/admin/characters");
+    revalidatePath("/admin/games");
+
+    return character;
+  });
+
+export const deleteCharacterAction = adminActionClient
+  .inputSchema(
+    z.object({
+      id: z.string().min(1, "L'ID du personnage est requis"),
+    }),
+  )
+  .action(async ({ parsedInput }) => {
+    await prisma.character.delete({
+      where: { id: parsedInput.id },
+    });
+
+    revalidatePath("/admin/characters");
+    revalidatePath("/admin/games");
+
+    return { success: true };
+  });

--- a/src/components/features/admin/character/character-form.tsx
+++ b/src/components/features/admin/character/character-form.tsx
@@ -17,64 +17,84 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
-import { gameFormSchema, GameFormSchemaType } from "./game-schema";
-import { createGameAction, updateGameAction } from "./game-action";
-import { AdminGameDetail } from "@/../prisma/query/admin-game.query";
+import {
+  characterFormSchema,
+  CharacterFormSchemaType,
+} from "./character-schema";
+import {
+  createCharacterAction,
+  updateCharacterAction,
+} from "./character-action";
+import { AdminCharacterDetail } from "@/../prisma/query/admin-character.query";
+import { GameOption } from "@/../prisma/query/game.query";
 import { generateSlug } from "@/lib/slug";
 
-interface GameFormProps {
+interface CharacterFormProps {
   mode: "create" | "edit";
-  game?: NonNullable<AdminGameDetail>;
+  character?: NonNullable<AdminCharacterDetail>;
+  games: GameOption[];
 }
 
-export function GameForm({ mode, game }: GameFormProps) {
+export function CharacterForm({ mode, character, games }: CharacterFormProps) {
   const router = useRouter();
 
   const { execute: createExecute, isPending: isCreating } = useAction(
-    createGameAction,
+    createCharacterAction,
     {
       onSuccess: () => {
-        toast.success("Jeu créé avec succès");
-        router.push("/admin/games");
+        toast.success("Personnage créé avec succès");
+        router.push("/admin/characters");
         router.refresh();
       },
       onError: ({ error }) => {
-        toast.error(error.serverError ?? "Erreur lors de la création du jeu");
+        toast.error(
+          error.serverError ?? "Erreur lors de la création du personnage",
+        );
       },
     },
   );
 
   const { execute: updateExecute, isPending: isUpdating } = useAction(
-    updateGameAction,
+    updateCharacterAction,
     {
       onSuccess: () => {
-        toast.success("Jeu mis à jour avec succès");
-        router.push("/admin/games");
+        toast.success("Personnage mis à jour avec succès");
+        router.push("/admin/characters");
         router.refresh();
       },
       onError: ({ error }) => {
-        toast.error(error.serverError ?? "Erreur lors de la mise à jour du jeu");
+        toast.error(
+          error.serverError ?? "Erreur lors de la mise à jour du personnage",
+        );
       },
     },
   );
 
-  const form = useForm<GameFormSchemaType>({
-    resolver: zodResolver(gameFormSchema),
+  const form = useForm<CharacterFormSchemaType>({
+    resolver: zodResolver(characterFormSchema),
     defaultValues: {
-      name: game?.name ?? "",
-      slug: game?.slug ?? "",
-      iconUrl: game?.iconUrl ?? "",
+      gameId: character?.gameId ?? "",
+      name: character?.name ?? "",
+      slug: character?.slug ?? "",
+      iconUrl: character?.iconUrl ?? "",
     },
   });
 
   const isPending = isCreating || isUpdating;
 
-  const onSubmit = (data: GameFormSchemaType) => {
+  const onSubmit = (data: CharacterFormSchemaType) => {
     if (mode === "create") {
       createExecute(data);
     } else {
-      updateExecute({ ...data, id: game!.id });
+      updateExecute({ ...data, id: character!.id });
     }
   };
 
@@ -88,7 +108,39 @@ export function GameForm({ mode, game }: GameFormProps) {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="max-w-xl space-y-6">
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="max-w-xl space-y-6"
+      >
+        <FormField
+          control={form.control}
+          name="gameId"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Jeu</FormLabel>
+              <Select
+                value={field.value}
+                onValueChange={field.onChange}
+                disabled={isPending}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Sélectionner un jeu" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {games.map((game) => (
+                    <SelectItem key={game.id} value={game.id}>
+                      {game.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
         <FormField
           control={form.control}
           name="name"
@@ -98,7 +150,7 @@ export function GameForm({ mode, game }: GameFormProps) {
               <FormControl>
                 <Input
                   {...field}
-                  placeholder="Ex : Street Fighter 6"
+                  placeholder="Ex : Ryu"
                   onBlur={handleNameBlur}
                 />
               </FormControl>
@@ -114,7 +166,7 @@ export function GameForm({ mode, game }: GameFormProps) {
             <FormItem>
               <FormLabel>Slug</FormLabel>
               <FormControl>
-                <Input {...field} placeholder="street-fighter-6" />
+                <Input {...field} placeholder="ryu" />
               </FormControl>
               <FormDescription>
                 Identifiant URL-friendly (auto-généré depuis le nom)
@@ -146,7 +198,7 @@ export function GameForm({ mode, game }: GameFormProps) {
           <Button
             type="button"
             variant="outline"
-            onClick={() => router.push("/admin/games")}
+            onClick={() => router.push("/admin/characters")}
             disabled={isPending}
           >
             Annuler
@@ -157,7 +209,7 @@ export function GameForm({ mode, game }: GameFormProps) {
                 ? "Création..."
                 : "Mise à jour..."
               : mode === "create"
-                ? "Créer le jeu"
+                ? "Créer le personnage"
                 : "Mettre à jour"}
           </Button>
         </div>

--- a/src/components/features/admin/character/character-list.tsx
+++ b/src/components/features/admin/character/character-list.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useAction } from "next-safe-action/hooks";
+import { toast } from "sonner";
+import { Edit, Trash2, MoreVertical } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+import { deleteCharacterAction } from "./character-action";
+import { AdminCharacterList } from "@/../prisma/query/admin-character.query";
+
+interface CharacterListProps {
+  characters: AdminCharacterList;
+}
+
+export function CharacterList({ characters }: CharacterListProps) {
+  const router = useRouter();
+  const [deleteDialog, setDeleteDialog] = useState<{
+    open: boolean;
+    character: AdminCharacterList[number] | null;
+  }>({
+    open: false,
+    character: null,
+  });
+
+  const { execute, isPending } = useAction(deleteCharacterAction, {
+    onSuccess: () => {
+      toast.success("Personnage supprimé avec succès");
+      setDeleteDialog({ open: false, character: null });
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? "Erreur lors de la suppression");
+    },
+  });
+
+  const openDeleteDialog = (character: AdminCharacterList[number]) => {
+    setDeleteDialog({ open: true, character });
+  };
+
+  const handleDelete = () => {
+    if (deleteDialog.character) {
+      execute({ id: deleteDialog.character.id });
+    }
+  };
+
+  if (characters.length === 0) {
+    return (
+      <div className="py-12 text-center">
+        <p className="text-muted-foreground mb-4">
+          Aucun personnage pour le moment
+        </p>
+        <Button asChild>
+          <Link href="/admin/characters/new">
+            Créer votre premier personnage
+          </Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const grouped = characters.reduce<
+    Record<string, { gameName: string; items: AdminCharacterList }>
+  >((acc, character) => {
+    const key = character.game.id;
+    if (!acc[key]) {
+      acc[key] = { gameName: character.game.name, items: [] };
+    }
+    acc[key].items.push(character);
+    return acc;
+  }, {});
+
+  return (
+    <>
+      <div className="space-y-8">
+        {Object.entries(grouped).map(([gameId, group]) => (
+          <section key={gameId} className="space-y-4">
+            <h2 className="text-xl font-semibold">{group.gameName}</h2>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {group.items.map((character) => (
+                <Card key={character.id}>
+                  <CardHeader>
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <CardTitle>{character.name}</CardTitle>
+                        <p className="text-muted-foreground text-sm">
+                          {character.slug}
+                        </p>
+                      </div>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon">
+                            <MoreVertical className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem asChild>
+                            <Link
+                              href={`/admin/characters/${character.id}/edit`}
+                              className="flex items-center"
+                            >
+                              <Edit className="mr-2 h-4 w-4" />
+                              Éditer
+                            </Link>
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => openDeleteDialog(character)}
+                            className="text-destructive"
+                          >
+                            <Trash2 className="mr-2 h-4 w-4" />
+                            Supprimer
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="text-muted-foreground flex items-center gap-4 text-xs">
+                      <span>{character._count.combos} combos</span>
+                      <span>{character._count.notes} notes</span>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      <AlertDialog
+        open={deleteDialog.open}
+        onOpenChange={(open) =>
+          !open && setDeleteDialog({ open: false, character: null })
+        }
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Supprimer ce personnage ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteDialog.character?.name}
+              <br />
+              <br />
+              Cela supprimera aussi tous les combos associés. Les notes liées
+              seront détachées. Cette action est irréversible.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isPending ? "Suppression..." : "Supprimer"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/features/admin/character/character-schema.test.ts
+++ b/src/components/features/admin/character/character-schema.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { characterFormSchema } from "./character-schema";
+
+describe("characterFormSchema", () => {
+  it("should validate correct character data", () => {
+    const result = characterFormSchema.safeParse({
+      gameId: "game-id-123",
+      name: "Ryu",
+      slug: "ryu",
+      iconUrl: "https://example.com/ryu.png",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept empty iconUrl", () => {
+    const result = characterFormSchema.safeParse({
+      gameId: "game-id-123",
+      name: "Ken",
+      slug: "ken",
+      iconUrl: "",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept omitted iconUrl", () => {
+    const result = characterFormSchema.safeParse({
+      gameId: "game-id-123",
+      name: "Chun-Li",
+      slug: "chun-li",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject empty gameId", () => {
+    const result = characterFormSchema.safeParse({
+      gameId: "",
+      name: "Ryu",
+      slug: "ryu",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject name shorter than 2 characters", () => {
+    const result = characterFormSchema.safeParse({
+      gameId: "game-id-123",
+      name: "R",
+      slug: "ryu",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject slug with uppercase letters", () => {
+    const result = characterFormSchema.safeParse({
+      gameId: "game-id-123",
+      name: "Ryu",
+      slug: "Ryu",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject slug with spaces", () => {
+    const result = characterFormSchema.safeParse({
+      gameId: "game-id-123",
+      name: "Chun Li",
+      slug: "chun li",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject invalid iconUrl", () => {
+    const result = characterFormSchema.safeParse({
+      gameId: "game-id-123",
+      name: "Ryu",
+      slug: "ryu",
+      iconUrl: "not-a-url",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject name over 60 characters", () => {
+    const result = characterFormSchema.safeParse({
+      gameId: "game-id-123",
+      name: "a".repeat(61),
+      slug: "ryu",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject slug over 40 characters", () => {
+    const result = characterFormSchema.safeParse({
+      gameId: "game-id-123",
+      name: "Ryu",
+      slug: "a".repeat(41),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/components/features/admin/character/character-schema.ts
+++ b/src/components/features/admin/character/character-schema.ts
@@ -1,0 +1,30 @@
+import z from "zod";
+
+export const characterFormSchema = z.object({
+  gameId: z.string().min(1, "Le jeu est requis"),
+  name: z
+    .string()
+    .min(2, "Le nom doit contenir au moins 2 caractères")
+    .max(60, "Le nom ne peut pas dépasser 60 caractères"),
+  slug: z
+    .string()
+    .min(1, "Le slug est requis")
+    .max(40, "Le slug ne peut pas dépasser 40 caractères")
+    .regex(
+      /^[a-z0-9-]+$/,
+      "Le slug ne peut contenir que des lettres minuscules, chiffres et tirets",
+    ),
+  iconUrl: z
+    .string()
+    .url("L'URL de l'icône n'est pas valide")
+    .optional()
+    .or(z.literal("")),
+});
+
+export type CharacterFormSchemaType = z.infer<typeof characterFormSchema>;
+
+export const createCharacterSchema = characterFormSchema;
+
+export const updateCharacterSchema = characterFormSchema.extend({
+  id: z.string().min(1),
+});

--- a/src/components/features/landing/authenticated-nav.tsx
+++ b/src/components/features/landing/authenticated-nav.tsx
@@ -22,6 +22,7 @@ export function AuthenticatedNav({ user }: AuthenticatedNavProps) {
         <>
           <NavLink href="/admin/glossary">Admin</NavLink>
           <NavLink href="/admin/games">Jeux</NavLink>
+          <NavLink href="/admin/characters">Personnages</NavLink>
         </>
       )}
       <UserProfileDropdown user={user} />

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,10 @@
+export function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .trim();
+}


### PR DESCRIPTION
## Summary

- Admin Characters CRUD via `/admin/characters` (liste groupée par jeu, create, edit, delete avec AlertDialog)
- Migration des queries Character / Game depuis `strategy-matrix.query.ts` vers `character.query.ts` et `game.query.ts` (re-exports préservent les imports existants — zéro breaking change)
- Extraction de `generateSlug` dans `src/lib/slug.ts`, réutilisé par `game-form` et `character-form`
- Check unicité composite `(gameId, slug)` dans `createCharacterAction` / `updateCharacterAction`
- 10 tests Vitest pour `character-schema`

## Hors scope (phase 3 ultérieure)

- Pages publiques `/characters` + `/characters/[gameSlug]/[charSlug]`
- Composants `CharacterCard`, `CharacterDetail`, `CharacterBadge`
- Lien user-facing `Personnages` dans nav
- Carnet Combos + intégration Note (extract-to-combo)

## Test plan

- [x] `pnpm ts` ✓
- [x] `pnpm lint` ✓ no warnings
- [x] `pnpm test:run` ✓ 85/85 (dont 10 nouveaux character-schema)
- [x] `pnpm build` ✓
- [ ] Login ADMIN, visiter `/admin/characters` → 24 perso seedés groupés par jeu
- [ ] Créer un perso via `/admin/characters/new` → redirect liste, perso visible
- [ ] Éditer un perso → persisté
- [ ] Supprimer un perso non-référencé → cascade combos OK, notes détachées
- [ ] Strategy Matrix `/notes/strategy/new` charge toujours games + characters
- [ ] Tenter accès non-admin à `/admin/characters` → redirect `/dashboard`