### PR TITLE
feat: character combo notebook phase 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-05-08
+
+### Changed: Combo form — pick game first, then filter characters by selected game
+
+### Added: Responsive burger menu in header below lg breakpoint (1024px)
+
+### Changed: Group admin nav links (Glossaire, Jeux, Personnages) under an Admin dropdown
+
+## 2026-05-03
+
+### Added: Personal combo notebook (CRUD) scoped per user with character + tags + notation
+
+### Added: Extract-to-combo button on video notes — prefills combo form from a note
+
+### Added: Recent combos section on dashboard
+
+### Added: User nav link to /combos
+
 ## 2026-05-02
 
 ### Added: Admin management for characters (CRUD)

--- a/app/(dashboard)/combos/[id]/edit/page.tsx
+++ b/app/(dashboard)/combos/[id]/edit/page.tsx
@@ -1,0 +1,38 @@
+import { notFound } from "next/navigation";
+
+import { requireAuth } from "@/lib/auth-utils";
+import { prisma } from "@/lib/prisma";
+import { getComboById } from "@/../prisma/query/combo.query";
+import { getAllCharactersWithGame } from "@/../prisma/query/character.query";
+import { ComboForm } from "@/components/features/combo/combo-form";
+
+interface EditComboPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function EditComboPage({ params }: EditComboPageProps) {
+  const user = await requireAuth();
+  const { id } = await params;
+
+  const [combo, characters, tags] = await Promise.all([
+    getComboById({ id, userId: user.id }),
+    getAllCharactersWithGame(),
+    prisma.tag.findMany({ orderBy: { name: "asc" } }),
+  ]);
+
+  if (!combo) {
+    notFound();
+  }
+
+  return (
+    <div className="container mx-auto max-w-7xl px-4 py-8">
+      <h1 className="mb-6 text-3xl font-bold">Modifier le combo</h1>
+      <ComboForm
+        mode="edit"
+        combo={combo}
+        characters={characters}
+        availableTags={tags}
+      />
+    </div>
+  );
+}

--- a/app/(dashboard)/combos/[id]/page.tsx
+++ b/app/(dashboard)/combos/[id]/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+import { requireAuth } from "@/lib/auth-utils";
+import { getComboById } from "@/../prisma/query/combo.query";
+import { ComboDetail } from "@/components/features/combo/combo-detail";
+import { Button } from "@/components/ui/button";
+
+interface ComboPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ComboPage({ params }: ComboPageProps) {
+  const user = await requireAuth();
+  const { id } = await params;
+  const combo = await getComboById({ id, userId: user.id });
+
+  if (!combo) {
+    notFound();
+  }
+
+  return (
+    <div className="container mx-auto max-w-5xl px-4 py-8">
+      <Button variant="ghost" size="sm" asChild className="mb-4">
+        <Link href="/combos">
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Retour aux combos
+        </Link>
+      </Button>
+      <ComboDetail combo={combo} />
+    </div>
+  );
+}

--- a/app/(dashboard)/combos/new/page.tsx
+++ b/app/(dashboard)/combos/new/page.tsx
@@ -1,0 +1,55 @@
+import { requireAuth } from "@/lib/auth-utils";
+import { prisma } from "@/lib/prisma";
+import { getAllCharactersWithGame } from "@/../prisma/query/character.query";
+import { ComboForm } from "@/components/features/combo/combo-form";
+
+interface NewComboPageProps {
+  searchParams: Promise<{ fromNote?: string; characterId?: string }>;
+}
+
+export default async function NewComboPage({ searchParams }: NewComboPageProps) {
+  const user = await requireAuth();
+  const { fromNote, characterId } = await searchParams;
+
+  const [characters, tags] = await Promise.all([
+    getAllCharactersWithGame(),
+    prisma.tag.findMany({ orderBy: { name: "asc" } }),
+  ]);
+
+  let prefillContent: string | undefined;
+  let resolvedCharacterId = characterId;
+  let resolvedSourceNoteId: string | undefined;
+
+  if (fromNote) {
+    const note = await prisma.note.findUnique({
+      where: { id: fromNote },
+      select: {
+        id: true,
+        content: true,
+        characterId: true,
+        match: { select: { userId: true } },
+      },
+    });
+    if (note && note.match.userId === user.id) {
+      prefillContent = note.content;
+      resolvedSourceNoteId = note.id;
+      if (!resolvedCharacterId && note.characterId) {
+        resolvedCharacterId = note.characterId;
+      }
+    }
+  }
+
+  return (
+    <div className="container mx-auto max-w-7xl px-4 py-8">
+      <h1 className="mb-6 text-3xl font-bold">Créer un nouveau combo</h1>
+      <ComboForm
+        mode="create"
+        characters={characters}
+        availableTags={tags}
+        defaultCharacterId={resolvedCharacterId}
+        sourceNoteId={resolvedSourceNoteId}
+        prefillContent={prefillContent}
+      />
+    </div>
+  );
+}

--- a/app/(dashboard)/combos/not-found.tsx
+++ b/app/(dashboard)/combos/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function ComboNotFound() {
+  return (
+    <div className="container mx-auto px-4 py-24 text-center">
+      <h1 className="text-3xl font-bold">Combo introuvable</h1>
+      <p className="text-muted-foreground mt-2">
+        Ce combo n&apos;existe pas ou ne vous appartient pas.
+      </p>
+      <Button asChild className="mt-6">
+        <Link href="/combos">Voir mes combos</Link>
+      </Button>
+    </div>
+  );
+}

--- a/app/(dashboard)/combos/page.tsx
+++ b/app/(dashboard)/combos/page.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { Plus } from "lucide-react";
+
+import { requireAuth } from "@/lib/auth-utils";
+import { getCombosByUser } from "@/../prisma/query/combo.query";
+import { ComboList } from "@/components/features/combo/combo-list";
+import { Button } from "@/components/ui/button";
+
+export default async function CombosPage() {
+  const user = await requireAuth();
+  const combos = await getCombosByUser({ userId: user.id });
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Mes combos</h1>
+          <p className="text-muted-foreground mt-1">
+            {combos.length} combo{combos.length > 1 ? "s" : ""}
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/combos/new">
+            <Plus className="mr-2 h-4 w-4" />
+            Nouveau combo
+          </Link>
+        </Button>
+      </div>
+      <ComboList combos={combos} />
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,10 +1,12 @@
 import { CTASection } from "@/components/features/dashboard/cta-section";
 import { HeroCarousel } from "@/components/features/dashboard/hero-carousel";
+import { RecentCombosSection } from "@/components/features/dashboard/recent-combos-section";
 import { RecentMatchesSection } from "@/components/features/dashboard/recent-matches-section";
 import { RecentStrategyMatricesSection } from "@/components/features/dashboard/recent-strategy-matrices-section";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { getRecentCombosForUser } from "../../../prisma/query/combo.query";
 import { getRecentMatches } from "../../../prisma/query/match.query";
 import { getRecentStrategyMatrices } from "../../../prisma/query/strategy-matrix.query";
 
@@ -15,10 +17,12 @@ export default async function DashboardPage() {
 
   if (!session?.user) redirect("/sign-in");
 
-  const [recentMatches, recentStrategyMatrices] = await Promise.all([
-    getRecentMatches({ userId: session.user.id }),
-    getRecentStrategyMatrices({ userId: session.user.id }),
-  ]);
+  const [recentMatches, recentStrategyMatrices, recentCombos] =
+    await Promise.all([
+      getRecentMatches({ userId: session.user.id }),
+      getRecentStrategyMatrices({ userId: session.user.id }),
+      getRecentCombosForUser({ userId: session.user.id }),
+    ]);
 
   return (
     <div className="mx-auto max-w-7xl space-y-12 px-4 py-8">
@@ -30,6 +34,7 @@ export default async function DashboardPage() {
         <RecentStrategyMatricesSection matrices={recentStrategyMatrices} />
         <RecentMatchesSection matches={recentMatches} />
       </div>
+      <RecentCombosSection combos={recentCombos} />
     </div>
   );
 }

--- a/prisma/query/character.query.ts
+++ b/prisma/query/character.query.ts
@@ -12,6 +12,22 @@ export type CharacterOption = Prisma.PromiseReturnType<
   typeof getCharactersByGame
 >[number];
 
+export const getAllCharactersWithGame = async () =>
+  await prisma.character.findMany({
+    select: {
+      id: true,
+      slug: true,
+      name: true,
+      iconUrl: true,
+      game: { select: { id: true, slug: true, name: true } },
+    },
+    orderBy: [{ game: { name: "asc" } }, { name: "asc" }],
+  });
+
+export type CharacterWithGame = Prisma.PromiseReturnType<
+  typeof getAllCharactersWithGame
+>[number];
+
 export const getAllCharactersGroupedByGame = async () => {
   const characters = await prisma.character.findMany({
     select: {

--- a/prisma/query/combo.query.ts
+++ b/prisma/query/combo.query.ts
@@ -1,0 +1,86 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "../../generated/prisma";
+
+const comboInclude = {
+  character: {
+    select: {
+      id: true,
+      slug: true,
+      name: true,
+      iconUrl: true,
+      game: {
+        select: { id: true, slug: true, name: true, iconUrl: true },
+      },
+    },
+  },
+  tags: { select: { id: true, name: true } },
+} satisfies Prisma.ComboInclude;
+
+export const getCombosByUser = async ({
+  userId,
+  characterId,
+  gameId,
+}: {
+  userId: string;
+  characterId?: string;
+  gameId?: string;
+}) =>
+  await prisma.combo.findMany({
+    where: {
+      userId,
+      ...(characterId ? { characterId } : {}),
+      ...(gameId ? { gameId } : {}),
+    },
+    include: comboInclude,
+    orderBy: { createdAt: "desc" },
+  });
+
+export type ComboListItem = Prisma.PromiseReturnType<
+  typeof getCombosByUser
+>[number];
+
+export const getRecentCombosForUser = async ({
+  userId,
+  limit = 5,
+}: {
+  userId: string;
+  limit?: number;
+}) =>
+  await prisma.combo.findMany({
+    where: { userId },
+    include: comboInclude,
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+
+export type RecentCombos = Prisma.PromiseReturnType<
+  typeof getRecentCombosForUser
+>;
+
+export const getComboById = async ({
+  id,
+  userId,
+}: {
+  id: string;
+  userId: string;
+}) =>
+  await prisma.combo.findFirst({
+    where: { id, userId },
+    include: {
+      ...comboInclude,
+      sourceNote: {
+        select: {
+          id: true,
+          content: true,
+          timestamp: true,
+          match: {
+            select: { id: true, title: true },
+          },
+        },
+      },
+    },
+  });
+
+export type ComboDetail = NonNullable<
+  Prisma.PromiseReturnType<typeof getComboById>
+>;

--- a/src/components/features/combo/combo-action.ts
+++ b/src/components/features/combo/combo-action.ts
@@ -1,0 +1,152 @@
+"use server";
+
+import { prisma } from "@/lib/prisma";
+import { authActionClient } from "@/lib/auth-action";
+import { revalidatePath } from "next/cache";
+import { createComboSchema, updateComboSchema } from "./combo-schema";
+import z from "zod";
+
+export const createComboAction = authActionClient
+  .inputSchema(createComboSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const {
+      characterId,
+      title,
+      notation,
+      damage,
+      meterUsed,
+      difficulty,
+      notes,
+      tagIds,
+      sourceNoteId,
+    } = parsedInput;
+
+    const character = await prisma.character.findUnique({
+      where: { id: characterId },
+      select: { id: true, gameId: true },
+    });
+
+    if (!character) {
+      throw new Error("Personnage introuvable");
+    }
+
+    if (sourceNoteId) {
+      const sourceNote = await prisma.note.findUnique({
+        where: { id: sourceNoteId },
+        select: { match: { select: { userId: true } } },
+      });
+      if (!sourceNote || sourceNote.match.userId !== ctx.user.id) {
+        throw new Error("Note source non autorisée");
+      }
+    }
+
+    const combo = await prisma.combo.create({
+      data: {
+        userId: ctx.user.id,
+        gameId: character.gameId,
+        characterId,
+        title,
+        notation,
+        damage,
+        meterUsed,
+        difficulty,
+        notes: notes && notes.length > 0 ? notes : null,
+        sourceNoteId: sourceNoteId ?? null,
+        tags: { connect: tagIds.map((id) => ({ id })) },
+      },
+    });
+
+    revalidatePath("/combos");
+    revalidatePath("/dashboard");
+
+    return combo;
+  });
+
+export const updateComboAction = authActionClient
+  .inputSchema(updateComboSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const {
+      id,
+      characterId,
+      title,
+      notation,
+      damage,
+      meterUsed,
+      difficulty,
+      notes,
+      tagIds,
+      sourceNoteId,
+    } = parsedInput;
+
+    const existing = await prisma.combo.findUnique({
+      where: { id },
+      select: { userId: true },
+    });
+
+    if (!existing) {
+      throw new Error("Combo introuvable");
+    }
+    if (existing.userId !== ctx.user.id) {
+      throw new Error("Non autorisé");
+    }
+
+    const character = await prisma.character.findUnique({
+      where: { id: characterId },
+      select: { id: true, gameId: true },
+    });
+
+    if (!character) {
+      throw new Error("Personnage introuvable");
+    }
+
+    const combo = await prisma.combo.update({
+      where: { id },
+      data: {
+        gameId: character.gameId,
+        characterId,
+        title,
+        notation,
+        damage,
+        meterUsed,
+        difficulty,
+        notes: notes && notes.length > 0 ? notes : null,
+        sourceNoteId: sourceNoteId ?? null,
+        tags: { set: tagIds.map((tagId) => ({ id: tagId })) },
+      },
+    });
+
+    revalidatePath("/combos");
+    revalidatePath(`/combos/${id}`);
+    revalidatePath("/dashboard");
+
+    return combo;
+  });
+
+export const deleteComboAction = authActionClient
+  .inputSchema(
+    z.object({
+      id: z.string().min(1, "L'ID du combo est requis"),
+    }),
+  )
+  .action(async ({ parsedInput, ctx }) => {
+    const existing = await prisma.combo.findUnique({
+      where: { id: parsedInput.id },
+      select: { userId: true },
+    });
+
+    if (!existing) {
+      throw new Error("Combo introuvable");
+    }
+    if (existing.userId !== ctx.user.id) {
+      throw new Error("Non autorisé");
+    }
+
+    await prisma.combo.delete({
+      where: { id: parsedInput.id },
+    });
+
+    revalidatePath("/combos");
+    revalidatePath("/dashboard");
+
+    return { success: true };
+  });

--- a/src/components/features/combo/combo-card.tsx
+++ b/src/components/features/combo/combo-card.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+import { Gauge, Heart, Zap } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ComboListItem } from "@/../prisma/query/combo.query";
+
+interface ComboCardProps {
+  combo: ComboListItem;
+}
+
+export function ComboCard({ combo }: ComboCardProps) {
+  return (
+    <Link href={`/combos/${combo.id}`}>
+      <Card className="border-border bg-card/50 hover:border-border/80 hover:bg-card cursor-pointer rounded-xl border backdrop-blur transition-all hover:-translate-y-0.5 hover:shadow-lg">
+        <CardHeader>
+          <div className="flex items-start justify-between gap-3">
+            <CardTitle className="text-lg">{combo.title}</CardTitle>
+            <div className="text-muted-foreground text-xs">
+              {new Date(combo.createdAt).toLocaleDateString()}
+            </div>
+          </div>
+          <div className="text-muted-foreground flex items-center gap-2 text-xs">
+            <span className="font-medium">{combo.character.name}</span>
+            <span>•</span>
+            <span>{combo.character.game.name}</span>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <code className="bg-muted block rounded-md px-3 py-2 font-mono text-sm break-words">
+            {combo.notation}
+          </code>
+          <div className="text-muted-foreground flex flex-wrap items-center gap-3 text-xs">
+            {combo.damage != null && (
+              <span className="flex items-center gap-1">
+                <Heart className="h-3.5 w-3.5" />
+                {combo.damage}
+              </span>
+            )}
+            {combo.meterUsed != null && (
+              <span className="flex items-center gap-1">
+                <Zap className="h-3.5 w-3.5" />
+                {combo.meterUsed}
+              </span>
+            )}
+            {combo.difficulty != null && (
+              <span className="flex items-center gap-1">
+                <Gauge className="h-3.5 w-3.5" />
+                {combo.difficulty}/5
+              </span>
+            )}
+          </div>
+          {combo.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {combo.tags.map((tag) => (
+                <Badge key={tag.id} variant="secondary" className="text-xs">
+                  {tag.name}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/features/combo/combo-detail.tsx
+++ b/src/components/features/combo/combo-detail.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAction } from "next-safe-action/hooks";
+import { toast } from "sonner";
+import { Copy, Edit, ExternalLink, Gauge, Heart, Trash2, Zap } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ComboDetail as ComboDetailType } from "@/../prisma/query/combo.query";
+
+import { deleteComboAction } from "./combo-action";
+
+interface ComboDetailProps {
+  combo: ComboDetailType;
+}
+
+export function ComboDetail({ combo }: ComboDetailProps) {
+  const router = useRouter();
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const { execute, isPending } = useAction(deleteComboAction, {
+    onSuccess: () => {
+      toast.success("Combo supprimé");
+      router.push("/combos");
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? "Erreur lors de la suppression");
+    },
+  });
+
+  const handleCopyNotation = async () => {
+    try {
+      await navigator.clipboard.writeText(combo.notation);
+      toast.success("Notation copiée");
+    } catch {
+      toast.error("Impossible de copier");
+    }
+  };
+
+  return (
+    <>
+      <div className="space-y-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold">{combo.title}</h1>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="outline">{combo.character.game.name}</Badge>
+              <Badge variant="secondary">{combo.character.name}</Badge>
+              {combo.tags.map((tag) => (
+                <Badge key={tag.id} variant="secondary">
+                  {tag.name}
+                </Badge>
+              ))}
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" onClick={handleCopyNotation}>
+              <Copy className="mr-2 h-4 w-4" />
+              Copier
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href={`/combos/${combo.id}/edit`}>
+                <Edit className="mr-2 h-4 w-4" />
+                Éditer
+              </Link>
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteOpen(true)}
+              className="text-destructive hover:text-destructive"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Supprimer
+            </Button>
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Notation</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <code className="bg-muted block rounded-md p-4 font-mono text-base break-words">
+              {combo.notation}
+            </code>
+          </CardContent>
+        </Card>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <Card>
+            <CardContent className="flex items-center gap-3 p-6">
+              <Heart className="text-muted-foreground h-5 w-5" />
+              <div>
+                <p className="text-muted-foreground text-xs">Dégâts</p>
+                <p className="text-lg font-semibold">{combo.damage ?? "—"}</p>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="flex items-center gap-3 p-6">
+              <Zap className="text-muted-foreground h-5 w-5" />
+              <div>
+                <p className="text-muted-foreground text-xs">Jauge</p>
+                <p className="text-lg font-semibold">
+                  {combo.meterUsed ?? "—"}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="flex items-center gap-3 p-6">
+              <Gauge className="text-muted-foreground h-5 w-5" />
+              <div>
+                <p className="text-muted-foreground text-xs">Difficulté</p>
+                <p className="text-lg font-semibold">
+                  {combo.difficulty ? `${combo.difficulty}/5` : "—"}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {combo.notes && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Notes</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm whitespace-pre-wrap">{combo.notes}</p>
+            </CardContent>
+          </Card>
+        )}
+
+        {combo.sourceNote && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Note source</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-muted-foreground text-sm">
+                Extrait depuis : {combo.sourceNote.match.title}
+              </p>
+              <p className="text-sm">{combo.sourceNote.content}</p>
+              <Button variant="outline" size="sm" asChild>
+                <Link
+                  href={`/videos/${combo.sourceNote.match.id}?t=${combo.sourceNote.timestamp}`}
+                >
+                  <ExternalLink className="mr-2 h-4 w-4" />
+                  Voir la note dans le replay
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Supprimer ce combo ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {combo.title}
+              <br />
+              <br />
+              Cette action est irréversible.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Annuler</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => execute({ id: combo.id })}
+              disabled={isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isPending ? "Suppression..." : "Supprimer"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/features/combo/combo-form.tsx
+++ b/src/components/features/combo/combo-form.tsx
@@ -1,0 +1,426 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useAction } from "next-safe-action/hooks";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { Tag } from "@/../generated/prisma";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+import { comboFormSchema, ComboFormSchemaType } from "./combo-schema";
+import { createComboAction, updateComboAction } from "./combo-action";
+import { ComboDetail } from "@/../prisma/query/combo.query";
+
+type CharacterOption = {
+  id: string;
+  slug: string;
+  name: string;
+  iconUrl: string | null;
+  game: { id: string; slug: string; name: string };
+};
+
+interface ComboFormProps {
+  mode: "create" | "edit";
+  combo?: ComboDetail;
+  characters: CharacterOption[];
+  availableTags: Tag[];
+  defaultCharacterId?: string;
+  sourceNoteId?: string;
+  prefillContent?: string;
+}
+
+export function ComboForm({
+  mode,
+  combo,
+  characters,
+  availableTags,
+  defaultCharacterId,
+  sourceNoteId,
+  prefillContent,
+}: ComboFormProps) {
+  const router = useRouter();
+
+  const initialTagIds = combo?.tags.map((t) => t.id) ?? [];
+  const [selectedTagIds, setSelectedTagIds] = useState<string[]>(initialTagIds);
+
+  const initialCharacter = combo?.character.id
+    ? characters.find((c) => c.id === combo.character.id)
+    : defaultCharacterId
+      ? characters.find((c) => c.id === defaultCharacterId)
+      : undefined;
+
+  const [selectedGameId, setSelectedGameId] = useState<string>(
+    initialCharacter?.game.id ?? "",
+  );
+
+  const games = useMemo(() => {
+    const map = new Map<string, { id: string; name: string }>();
+    for (const character of characters) {
+      if (!map.has(character.game.id)) {
+        map.set(character.game.id, {
+          id: character.game.id,
+          name: character.game.name,
+        });
+      }
+    }
+    return Array.from(map.values()).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+  }, [characters]);
+
+  const charactersForGame = useMemo(
+    () =>
+      characters
+        .filter((character) => character.game.id === selectedGameId)
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [characters, selectedGameId],
+  );
+
+  const { execute: createExecute, isPending: isCreating } = useAction(
+    createComboAction,
+    {
+      onSuccess: () => {
+        toast.success("Combo créé avec succès");
+        router.push("/combos");
+        router.refresh();
+      },
+      onError: ({ error }) => {
+        toast.error(error.serverError ?? "Erreur lors de la création du combo");
+      },
+    },
+  );
+
+  const { execute: updateExecute, isPending: isUpdating } = useAction(
+    updateComboAction,
+    {
+      onSuccess: () => {
+        toast.success("Combo mis à jour avec succès");
+        router.push(`/combos/${combo!.id}`);
+        router.refresh();
+      },
+      onError: ({ error }) => {
+        toast.error(
+          error.serverError ?? "Erreur lors de la mise à jour du combo",
+        );
+      },
+    },
+  );
+
+  const form = useForm<ComboFormSchemaType>({
+    resolver: zodResolver(comboFormSchema),
+    defaultValues: {
+      characterId: combo?.character.id ?? defaultCharacterId ?? "",
+      title: combo?.title ?? "",
+      notation: combo?.notation ?? prefillContent ?? "",
+      damage: combo?.damage ?? undefined,
+      meterUsed: combo?.meterUsed ?? undefined,
+      difficulty: combo?.difficulty ?? undefined,
+      notes: combo?.notes ?? "",
+      tagIds: initialTagIds,
+      sourceNoteId: combo?.sourceNoteId ?? sourceNoteId,
+    },
+  });
+
+  const isPending = isCreating || isUpdating;
+
+  const toggleTag = (tagId: string) => {
+    setSelectedTagIds((prev) => {
+      const next = prev.includes(tagId)
+        ? prev.filter((id) => id !== tagId)
+        : prev.length < 10
+          ? [...prev, tagId]
+          : prev;
+      form.setValue("tagIds", next, { shouldValidate: true });
+      return next;
+    });
+  };
+
+  const onSubmit = (data: ComboFormSchemaType) => {
+    if (mode === "create") {
+      createExecute(data);
+    } else {
+      updateExecute({ ...data, id: combo!.id });
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="max-w-2xl space-y-6"
+      >
+        <FormItem>
+          <FormLabel>Jeu</FormLabel>
+          <Select
+            value={selectedGameId}
+            onValueChange={(value) => {
+              setSelectedGameId(value);
+              form.setValue("characterId", "", { shouldValidate: true });
+            }}
+            disabled={isPending}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Sélectionner un jeu" />
+            </SelectTrigger>
+            <SelectContent>
+              {games.map((game) => (
+                <SelectItem key={game.id} value={game.id}>
+                  {game.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </FormItem>
+
+        <FormField
+          control={form.control}
+          name="characterId"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Personnage</FormLabel>
+              <Select
+                value={field.value}
+                onValueChange={(value) =>
+                  form.setValue("characterId", value, { shouldValidate: true })
+                }
+                disabled={isPending || !selectedGameId}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue
+                      placeholder={
+                        selectedGameId
+                          ? "Sélectionner un personnage"
+                          : "Sélectionnez un jeu d'abord"
+                      }
+                    />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {charactersForGame.map((character) => (
+                    <SelectItem key={character.id} value={character.id}>
+                      {character.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Titre</FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  placeholder="Ex : Bread and butter midscreen"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="notation"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Notation</FormLabel>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  placeholder="Ex : 2MP > 2HP xx 236P, SA1"
+                  className="min-h-[100px] font-mono"
+                />
+              </FormControl>
+              <FormDescription>
+                Utilisez la notation FGC habituelle (numpad ou directionnelle)
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <FormField
+            control={form.control}
+            name="damage"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Dégâts</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={9999}
+                    placeholder="3500"
+                    value={field.value ?? ""}
+                    onChange={(e) =>
+                      field.onChange(
+                        e.target.value === ""
+                          ? undefined
+                          : Number(e.target.value),
+                      )
+                    }
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="meterUsed"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Jauge utilisée</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={10}
+                    placeholder="1"
+                    value={field.value ?? ""}
+                    onChange={(e) =>
+                      field.onChange(
+                        e.target.value === ""
+                          ? undefined
+                          : Number(e.target.value),
+                      )
+                    }
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="difficulty"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Difficulté (1-5)</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={5}
+                    placeholder="3"
+                    value={field.value ?? ""}
+                    onChange={(e) =>
+                      field.onChange(
+                        e.target.value === ""
+                          ? undefined
+                          : Number(e.target.value),
+                      )
+                    }
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <FormField
+          control={form.control}
+          name="notes"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Notes (optionnel)</FormLabel>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  value={field.value ?? ""}
+                  placeholder="Détails, conditions, alternatives..."
+                  className="min-h-[80px]"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="space-y-3">
+          <FormLabel>Tags ({selectedTagIds.length}/10)</FormLabel>
+          <FormDescription>
+            Sélectionnez les tags qui décrivent ce combo
+          </FormDescription>
+          <div className="flex flex-wrap gap-2">
+            {availableTags.map((tag) => {
+              const isSelected = selectedTagIds.includes(tag.id);
+              const isDisabled = !isSelected && selectedTagIds.length >= 10;
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => toggleTag(tag.id)}
+                  disabled={isDisabled}
+                  className={cn(
+                    "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                    isSelected
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+                    isDisabled && "cursor-not-allowed opacity-50",
+                  )}
+                >
+                  {tag.name}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="flex gap-4">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.back()}
+            disabled={isPending}
+          >
+            Annuler
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {isPending
+              ? mode === "create"
+                ? "Création..."
+                : "Mise à jour..."
+              : mode === "create"
+                ? "Créer le combo"
+                : "Mettre à jour"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/features/combo/combo-list.tsx
+++ b/src/components/features/combo/combo-list.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { ComboListItem } from "@/../prisma/query/combo.query";
+
+import { ComboCard } from "./combo-card";
+
+interface ComboListProps {
+  combos: ComboListItem[];
+}
+
+export function ComboList({ combos }: ComboListProps) {
+  if (combos.length === 0) {
+    return (
+      <div className="py-12 text-center">
+        <p className="text-muted-foreground mb-4">
+          Aucun combo pour le moment
+        </p>
+        <Button asChild>
+          <Link href="/combos/new">Créer votre premier combo</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {combos.map((combo) => (
+        <ComboCard key={combo.id} combo={combo} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/features/combo/combo-schema.test.ts
+++ b/src/components/features/combo/combo-schema.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { comboFormSchema } from "./combo-schema";
+
+describe("comboFormSchema", () => {
+  it("should validate a minimal combo", () => {
+    const result = comboFormSchema.safeParse({
+      characterId: "char-1",
+      title: "Drive Rush combo",
+      notation: "5MP > 2HP xx 236P",
+      tagIds: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should validate a complete combo", () => {
+    const result = comboFormSchema.safeParse({
+      characterId: "char-1",
+      title: "Bread and butter",
+      notation: "j.HK, 5MP, 2MP xx 214K, SA1",
+      damage: 3500,
+      meterUsed: 1,
+      difficulty: 3,
+      notes: "Hit confirm depuis le j.HK",
+      tagIds: ["tag-1", "tag-2"],
+      sourceNoteId: "note-1",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept numeric form values", () => {
+    const result = comboFormSchema.safeParse({
+      characterId: "char-1",
+      title: "Test",
+      notation: "X",
+      damage: 1500,
+      meterUsed: 2,
+      difficulty: 4,
+      tagIds: [],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.damage).toBe(1500);
+      expect(result.data.meterUsed).toBe(2);
+      expect(result.data.difficulty).toBe(4);
+    }
+  });
+
+  it("should accept omitted optional fields", () => {
+    const result = comboFormSchema.safeParse({
+      characterId: "char-1",
+      title: "Test",
+      notation: "X",
+      tagIds: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject empty characterId", () => {
+    const result = comboFormSchema.safeParse({
+      characterId: "",
+      title: "Test",
+      notation: "X",
+      tagIds: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject title shorter than 2 chars", () => {
+    const result = comboFormSchema.safeParse({
+      characterId: "char-1",
+      title: "T",
+      notation: "X",
+      tagIds: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject empty notation", () => {
+    const result = comboFormSchema.safeParse({
+      characterId: "char-1",
+      title: "Test",
+      notation: "",
+      tagIds: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject damage out of range", () => {
+    const result = comboFormSchema.safeParse({
+      characterId: "char-1",
+      title: "Test",
+      notation: "X",
+      damage: 10000,
+      tagIds: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject meterUsed > 10", () => {
+    const result = comboFormSchema.safeParse({
+      characterId: "char-1",
+      title: "Test",
+      notation: "X",
+      meterUsed: 15,
+      tagIds: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject difficulty < 1 or > 5", () => {
+    const r1 = comboFormSchema.safeParse({
+      characterId: "char-1",
+      title: "Test",
+      notation: "X",
+      difficulty: 0,
+      tagIds: [],
+    });
+    const r2 = comboFormSchema.safeParse({
+      characterId: "char-1",
+      title: "Test",
+      notation: "X",
+      difficulty: 6,
+      tagIds: [],
+    });
+    expect(r1.success).toBe(false);
+    expect(r2.success).toBe(false);
+  });
+
+  it("should reject more than 10 tags", () => {
+    const result = comboFormSchema.safeParse({
+      characterId: "char-1",
+      title: "Test",
+      notation: "X",
+      tagIds: Array.from({ length: 11 }, (_, i) => `tag-${i}`),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject notation over 500 chars", () => {
+    const result = comboFormSchema.safeParse({
+      characterId: "char-1",
+      title: "Test",
+      notation: "X".repeat(501),
+      tagIds: [],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/components/features/combo/combo-schema.ts
+++ b/src/components/features/combo/combo-schema.ts
@@ -1,0 +1,30 @@
+import z from "zod";
+
+export const comboFormSchema = z.object({
+  characterId: z.string().min(1, "Le personnage est requis"),
+  title: z
+    .string()
+    .min(2, "Le titre doit contenir au moins 2 caractères")
+    .max(120, "Le titre ne peut pas dépasser 120 caractères"),
+  notation: z
+    .string()
+    .min(1, "La notation est requise")
+    .max(500, "La notation ne peut pas dépasser 500 caractères"),
+  damage: z.number().int().min(0).max(9999).optional(),
+  meterUsed: z.number().int().min(0).max(10).optional(),
+  difficulty: z.number().int().min(1).max(5).optional(),
+  notes: z
+    .string()
+    .max(2000, "Les notes ne peuvent pas dépasser 2000 caractères")
+    .optional(),
+  tagIds: z.array(z.string()).max(10, "Maximum 10 tags autorisés"),
+  sourceNoteId: z.string().optional(),
+});
+
+export type ComboFormSchemaType = z.infer<typeof comboFormSchema>;
+
+export const createComboSchema = comboFormSchema;
+
+export const updateComboSchema = comboFormSchema.extend({
+  id: z.string().min(1),
+});

--- a/src/components/features/dashboard/recent-combos-section.tsx
+++ b/src/components/features/dashboard/recent-combos-section.tsx
@@ -1,0 +1,38 @@
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+import { RecentCombos } from "../../../../prisma/query/combo.query";
+import { ComboCard } from "../combo/combo-card";
+
+type RecentCombosSectionProps = {
+  combos: RecentCombos;
+};
+
+export function RecentCombosSection({ combos }: RecentCombosSectionProps) {
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-semibold">Derniers combos</h2>
+        <Link
+          href="/combos"
+          className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors hover:underline"
+        >
+          Voir tout <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+
+      {combos.length === 0 ? (
+        <div className="text-muted-foreground py-12 text-center">
+          <p>Aucun combo pour le moment.</p>
+          <p className="mt-2 text-sm">Créez votre premier combo !</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {combos.map((combo) => (
+            <ComboCard key={combo.id} combo={combo} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/features/landing/authenticated-nav.tsx
+++ b/src/components/features/landing/authenticated-nav.tsx
@@ -1,7 +1,21 @@
 "use client";
 
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChevronDown, Menu } from "lucide-react";
+
 import { UserProfileDropdown } from "@/components/features/auth/user-profile-dropdown";
 import { NavLink } from "@/components/features/landing/nav-link";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 
 interface AuthenticatedNavProps {
   user: {
@@ -13,19 +27,86 @@ interface AuthenticatedNavProps {
 }
 
 export function AuthenticatedNav({ user }: AuthenticatedNavProps) {
+  const pathname = usePathname();
+  const isAdminActive = pathname.startsWith("/admin");
+
   return (
-    <div className="flex items-center gap-4">
-      <NavLink href="/dashboard">Dashboard</NavLink>
-      <NavLink href="/glossary">Glossaire</NavLink>
-      <NavLink href="/stream">Stream</NavLink>
-      {user.role === "ADMIN" && (
-        <>
-          <NavLink href="/admin/glossary">Admin</NavLink>
-          <NavLink href="/admin/games">Jeux</NavLink>
-          <NavLink href="/admin/characters">Personnages</NavLink>
-        </>
-      )}
-      <UserProfileDropdown user={user} />
-    </div>
+    <>
+      <div className="hidden items-center gap-4 lg:flex">
+        <NavLink href="/dashboard">Dashboard</NavLink>
+        <NavLink href="/combos">Combos</NavLink>
+        <NavLink href="/glossary">Glossaire</NavLink>
+        <NavLink href="/stream">Stream</NavLink>
+        {user.role === "ADMIN" && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                className={cn(
+                  "gap-1",
+                  isAdminActive &&
+                    "bg-accent text-accent-foreground hover:bg-accent/80",
+                )}
+              >
+                Admin
+                <ChevronDown className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem asChild>
+                <Link href="/admin/glossary">Glossaire</Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/admin/games">Jeux</Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/admin/characters">Personnages</Link>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+        <UserProfileDropdown user={user} />
+      </div>
+
+      <div className="flex items-center gap-2 lg:hidden">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label="Menu">
+              <Menu className="h-5 w-5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-56">
+            <DropdownMenuItem asChild>
+              <Link href="/dashboard">Dashboard</Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/combos">Combos</Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/glossary">Glossaire</Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/stream">Stream</Link>
+            </DropdownMenuItem>
+            {user.role === "ADMIN" && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel>Admin</DropdownMenuLabel>
+                <DropdownMenuItem asChild>
+                  <Link href="/admin/glossary">Glossaire</Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link href="/admin/games">Jeux</Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link href="/admin/characters">Personnages</Link>
+                </DropdownMenuItem>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <UserProfileDropdown user={user} />
+      </div>
+    </>
   );
 }

--- a/src/components/features/video/note-list.tsx
+++ b/src/components/features/video/note-list.tsx
@@ -3,7 +3,8 @@
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { Trash2 } from "lucide-react";
+import Link from "next/link";
+import { Swords, Trash2 } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
 
 import { Note, Tag } from "@/../generated/prisma";
@@ -70,15 +71,29 @@ function NoteItem({ note, isActive, onClick, onDelete }: NoteItemProps) {
         >
           {formatTime(note.timestamp)}
         </div>
-        <button
-          type="button"
-          onClick={() => onDelete(note)}
-          className="hover:bg-destructive/10 hover:text-destructive rounded-md p-1.5 transition-colors"
-          aria-label="Supprimer la note"
-        >
-          <Trash2 className="h-4 w-4" />
-          <span className="sr-only">Supprimer la note</span>
-        </button>
+        <div className="flex items-center gap-1">
+          <Link
+            href={`/combos/new?fromNote=${note.id}`}
+            onClick={(e) => e.stopPropagation()}
+            className="hover:bg-primary/10 hover:text-primary rounded-md p-1.5 transition-colors"
+            aria-label="Extraire en combo"
+          >
+            <Swords className="h-4 w-4" />
+            <span className="sr-only">Extraire en combo</span>
+          </Link>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(note);
+            }}
+            className="hover:bg-destructive/10 hover:text-destructive rounded-md p-1.5 transition-colors"
+            aria-label="Supprimer la note"
+          >
+            <Trash2 className="h-4 w-4" />
+            <span className="sr-only">Supprimer la note</span>
+          </button>
+        </div>
       </div>
       <p className="text-sm leading-relaxed font-medium text-black">
         {note.content}


### PR DESCRIPTION


- Changed: Combo form — pick game first, then filter characters by selected game

- Added: Responsive burger menu in header below lg breakpoint (1024px)

- Changed: Group admin nav links (Glossaire, Jeux, Personnages) under an Admin dropdown

- Added: Personal combo notebook (CRUD) scoped per user with character + tags + notation

- Added: Extract-to-combo button on video notes — prefills combo form from a note

- Added: Recent combos section on dashboard

- Added: User nav link to /combos