### PR TITLE
feat(videos): list all user replays on /videos page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-05-24
+
+### Added: List all user replays on /videos page
+
 ## 2026-05-08
 
 ### Changed: Combo form — pick game first, then filter characters by selected game

--- a/app/videos/page.tsx
+++ b/app/videos/page.tsx
@@ -1,41 +1,45 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { prisma } from "@/lib/prisma";
-import { auth } from "@/lib/auth";
-import { headers } from "next/headers";
-import { redirect } from "next/navigation";
+import { ReplayCard } from "@/components/features/dashboard/replay-card";
+import { Button } from "@/components/ui/button";
+import { requireAuth } from "@/lib/auth-utils";
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import { getMatchesByUser } from "../../prisma/query/match.query";
 
 export default async function VideosPage() {
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
-
-  if (!session?.user) {
-    redirect("/sign-in");
-  }
-
-  const matches = await prisma.match.findMany({
-    where: {
-      userId: session.user.id,
-    },
-  });
-
-  if (!matches) {
-    return (
-      <Card>
-        <CardContent>
-          <CardHeader>
-            <CardTitle>Aucune vidéo trouvée</CardTitle>
-          </CardHeader>
-        </CardContent>
-      </Card>
-    );
-  }
+  const user = await requireAuth();
+  const matches = await getMatchesByUser({ userId: user.id });
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Test</CardTitle>
-      </CardHeader>
-    </Card>
+    <div className="mx-auto max-w-7xl space-y-6 px-4 py-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Mes replays</h1>
+          <p className="text-muted-foreground mt-1">
+            {matches.length} replay{matches.length > 1 ? "s" : ""}
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/videos/new">
+            <Plus className="mr-2 h-4 w-4" />
+            Nouveau replay
+          </Link>
+        </Button>
+      </div>
+
+      {matches.length === 0 ? (
+        <div className="text-muted-foreground py-12 text-center">
+          <p>Aucun replay pour le moment.</p>
+          <p className="mt-2 text-sm">
+            Ajoutez votre premier replay avec un lien YouTube !
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {matches.map((match) => (
+            <ReplayCard key={match.id} match={match} />
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/prisma/query/match.query.ts
+++ b/prisma/query/match.query.ts
@@ -24,3 +24,26 @@ export const getRecentMatches = async ({ userId }: { userId: string }) =>
   });
 
 export type RecentMatches = Prisma.PromiseReturnType<typeof getRecentMatches>;
+
+export const getMatchesByUser = async ({ userId }: { userId: string }) =>
+  await prisma.match.findMany({
+    where: {
+      userId,
+    },
+    select: {
+      id: true,
+      title: true,
+      matchType: true,
+      status: true,
+      duration: true,
+      createdAt: true,
+      _count: {
+        select: {
+          notes: true,
+        },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+export type UserMatches = Prisma.PromiseReturnType<typeof getMatchesByUser>;


### PR DESCRIPTION
## Summary

- Replace `/videos` placeholder with full replay listing
- Add `getMatchesByUser` query (all matches, sorted desc)
- Reuse `ReplayCard` from dashboard for consistency
- Empty state + "Nouveau replay" CTA

## Type

feat