### PR TITLE
feat(strategy-matrix): visualize matrix in modal dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## 2026-05-24
 
+### Changed: Replace strategy matrix card actions (Ouvrir, Visualiser, Supprimer) with icon buttons + tooltips
+
+### Added: Visualize strategy matrix in a read-only modal from the matrix list
+
 ### Added: List all user replays on /videos page
 
 ## 2026-05-08

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -27,7 +27,17 @@ export default async function DashboardPage() {
   return (
     <div className="mx-auto max-w-7xl space-y-12 px-4 py-8">
       <div className="mx-auto w-full max-w-2xl">
-        <HeroCarousel slides={[]} />
+        <HeroCarousel
+          slides={[
+            {
+              image: "",
+              link: "https://fullmeter.com/fatonline/#/quicksearch",
+              title: "Full meter",
+              description:
+                "Site complet pour la frame data de street fighter 6 et autre proposition",
+            },
+          ]}
+        />
       </div>
       <CTASection />
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2">

--- a/prisma/query/strategy-matrix.query.ts
+++ b/prisma/query/strategy-matrix.query.ts
@@ -41,6 +41,7 @@ export const getStrategyMatrices = async ({
       description: true,
       myAxis: true,
       opponentAxis: true,
+      cells: true,
       pinned: true,
       createdAt: true,
       updatedAt: true,

--- a/src/components/features/dashboard/hero-carousel.tsx
+++ b/src/components/features/dashboard/hero-carousel.tsx
@@ -48,7 +48,7 @@ export function HeroCarousel({ slides }: HeroCarouselProps) {
       <CarouselContent>
         {slides.map((slide, index) => (
           <CarouselItem key={index}>
-            <Link href={slide.link}>
+            <Link href={slide.link} target="_blank">
               <div className="flex h-[400px] cursor-pointer flex-col items-center justify-center rounded-3xl bg-gradient-to-r from-orange-400 via-red-500 to-pink-500 p-12 text-center text-white transition-transform duration-300 hover:scale-[1.02]">
                 <h2 className="mb-4 text-4xl font-bold">{slide.title}</h2>
                 {slide.description && (

--- a/src/components/features/strategy-matrix/strategy-matrix-list.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-list.tsx
@@ -13,10 +13,17 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { FolderOpen, Trash2 } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import { StrategyMatrixVisualizeDialog } from "./strategy-matrix-visualize-dialog";
 import { axisSchema } from "./strategy-matrix-schema";
 import type { StrategyMatrixListItem } from "../../../../prisma/query/strategy-matrix.query";
 import { deleteStrategyMatrixAction } from "./strategy-matrix-action";
@@ -89,16 +96,42 @@ export function StrategyMatrixList({ matrices }: Props) {
             {safeAxisLabel(matrix.myAxis)} ×{" "}
             {safeAxisLabel(matrix.opponentAxis)}
           </div>
-          <div className="mt-auto flex gap-2">
-            <Button asChild size="sm" className="flex-1">
-              <Link href={`/notes/strategy/${matrix.id}`}>Ouvrir</Link>
-            </Button>
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="outline" size="sm" disabled={isPending}>
-                  Supprimer
+          <div className="mt-auto flex justify-end gap-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button asChild size="icon" variant="outline">
+                  <Link
+                    href={`/notes/strategy/${matrix.id}`}
+                    aria-label="Ouvrir"
+                  >
+                    <FolderOpen className="h-4 w-4" />
+                  </Link>
                 </Button>
-              </AlertDialogTrigger>
+              </TooltipTrigger>
+              <TooltipContent>Ouvrir</TooltipContent>
+            </Tooltip>
+            <StrategyMatrixVisualizeDialog
+              title={matrix.title}
+              myAxis={matrix.myAxis}
+              opponentAxis={matrix.opponentAxis}
+              cells={matrix.cells}
+            />
+            <AlertDialog>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      disabled={isPending}
+                      aria-label="Supprimer"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </AlertDialogTrigger>
+                </TooltipTrigger>
+                <TooltipContent>Supprimer</TooltipContent>
+              </Tooltip>
               <AlertDialogContent>
                 <AlertDialogHeader>
                   <AlertDialogTitle>Supprimer cette matrice ?</AlertDialogTitle>

--- a/src/components/features/strategy-matrix/strategy-matrix-visualize-dialog.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-visualize-dialog.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Eye } from "lucide-react";
+import { useMemo, useState } from "react";
+import z from "zod";
+import { StrategyMatrixGrid } from "./strategy-matrix-grid";
+import { axisSchema, cellSchema } from "./strategy-matrix-schema";
+
+type Props = {
+  title: string;
+  myAxis: unknown;
+  opponentAxis: unknown;
+  cells: unknown;
+};
+
+export function StrategyMatrixVisualizeDialog({
+  title,
+  myAxis,
+  opponentAxis,
+  cells,
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  const parsed = useMemo(() => {
+    const my = axisSchema.safeParse(myAxis);
+    const opp = axisSchema.safeParse(opponentAxis);
+    const c = z.array(cellSchema).safeParse(cells);
+    if (!my.success || !opp.success || !c.success) return null;
+    return { myAxis: my.data, opponentAxis: opp.data, cells: c.data };
+  }, [myAxis, opponentAxis, cells]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <Button variant="outline" size="icon" aria-label="Visualiser">
+              <Eye className="h-4 w-4" />
+            </Button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Visualiser</TooltipContent>
+      </Tooltip>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[90vw]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        {parsed ? (
+          <StrategyMatrixGrid
+            myAxis={parsed.myAxis}
+            opponentAxis={parsed.opponentAxis}
+            cells={parsed.cells}
+            readOnly
+          />
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            Impossible d&apos;afficher cette matrice.
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `strategy-matrix-visualize-dialog` component
- Wire visualize action in strategy matrix list
- Surface matrices on dashboard page
- Minor hero carousel tweak

## Type

feat