### PR TITLE
feat(rag): semantic search with pgvector + Cmd+K spotlight dialog

### DIFF
--- a/.claude/rules/rag.md
+++ b/.claude/rules/rag.md
@@ -1,0 +1,29 @@
+# RAG / Semantic Search
+
+Semantic search infrastructure for `Note` and `GlossaryArticle`.
+
+## Stack
+
+- **pgvector** extension on Neon Postgres (declared via `Unsupported("vector(1536)")` in `prisma/schema.prisma`)
+- **OpenAI `text-embedding-3-small`** (1536 dims) — wrapper in `src/lib/ai/openai.ts`
+- **HNSW** index with `vector_cosine_ops` (`m = 16`, `ef_construction = 64`)
+- **Indexation** : background via `after()` from `next/server` inside server actions (no queue)
+
+## Layout
+
+- `src/lib/ai/openai.ts` — `generateEmbedding`, `generateEmbeddingsBatch` (null-safe like Groq client)
+- `src/lib/rag/content-hash.ts` — sha256 hash for change detection
+- `src/lib/rag/embed-content.ts` — `embedNoteIfNeeded`, `embedGlossaryArticleIfNeeded` (skip when hash + model unchanged)
+- `src/lib/rag/search-notes.ts` — cosine search scoped by `Match.userId`
+- `src/lib/rag/search-glossary.ts` — cosine search on `published = true` articles
+- `src/components/features/search/` — `semanticSearchAction` (authActionClient) + UI
+- `app/(dashboard)/search/page.tsx` — entry page
+- `scripts/backfill-embeddings.ts` — one-shot via `pnpm backfill:embeddings`
+
+## Conventions
+
+- Always embed via the `embed-content.ts` helpers — they check `contentHash` to avoid duplicate API calls
+- Search queries that scope by user MUST join `Match` for notes (Note has no direct userId)
+- pgvector has no native pre-filter — server-side over-fetch + WHERE clause is fine for <10k rows per user
+- New tables that need RAG : add `embedding Unsupported("vector(1536)")?` + `contentHash String?` + `embeddingModel String?` + manual HNSW migration
+- Cast vectors with `Prisma.raw(\`'\${literal}'::vector\`)`in`$queryRaw` / `$executeRaw`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-05-30
+
+### Added: Cmd+K spotlight dialog for semantic search from anywhere in the dashboard
+
 ## 2026-05-25
 
 ### Added: Semantic search infrastructure with pgvector and OpenAI embeddings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-05-25
+
+### Added: Semantic search infrastructure with pgvector and OpenAI embeddings
+
+### Added: Semantic search page on /search for notes and glossary
+
+### Added: Backfill script for existing notes and glossary embeddings
+
 ## 2026-05-24
 
 ### Changed: Replace strategy matrix card actions (Ouvrir, Visualiser, Supprimer) with icon buttons + tooltips

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added: Cmd+K spotlight dialog for semantic search from anywhere in the dashboard
 
+### Fixed: Load .env in backfill:embeddings script so t3-env validation passes when run via tsx
+
 ## 2026-05-25
 
 ### Added: Semantic search infrastructure with pgvector and OpenAI embeddings

--- a/__mocks__/openai.ts
+++ b/__mocks__/openai.ts
@@ -1,0 +1,37 @@
+import { vi } from "vitest";
+
+export function fakeEmbedding(seed = 0, dims = 1536): number[] {
+  return Array.from({ length: dims }, (_, i) => (i + seed) / dims);
+}
+
+export type OpenAIMockOptions = {
+  throwError?: boolean;
+  customResponse?: (input: string | string[]) => Array<{
+    embedding: number[];
+    index: number;
+  }>;
+};
+
+export function createOpenAIMock(opts: OpenAIMockOptions = {}) {
+  const create = vi.fn(async ({ input }: { input: string | string[] }) => {
+    if (opts.throwError) {
+      throw new Error("openai mock error");
+    }
+    const inputs = Array.isArray(input) ? input : [input];
+    const data = opts.customResponse
+      ? opts.customResponse(input)
+      : inputs.map((_, i) => ({ embedding: fakeEmbedding(i), index: i }));
+    return {
+      data,
+      usage: { prompt_tokens: 10, total_tokens: 10 },
+      model: "text-embedding-3-small",
+      object: "list" as const,
+    };
+  });
+
+  const ClassMock = vi.fn().mockImplementation(() => ({
+    embeddings: { create },
+  }));
+
+  return { ClassMock, create };
+}

--- a/app/(dashboard)/search/page.tsx
+++ b/app/(dashboard)/search/page.tsx
@@ -1,0 +1,20 @@
+import { SemanticSearchBar } from "@/components/features/search/semantic-search-bar";
+
+export const metadata = {
+  title: "Recherche sémantique",
+};
+
+export default function SearchPage() {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-8">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold">Recherche sémantique</h1>
+        <p className="text-muted-foreground mt-2 text-sm">
+          Cherche dans tes notes timestampées et les articles du glossaire par
+          sens, pas seulement par mots-clés.
+        </p>
+      </header>
+      <SemanticSearchBar />
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:all": "pnpm test:run && pnpm test:e2e",
+    "backfill:embeddings": "tsx scripts/backfill-embeddings.ts",
     "sync-main": "git checkout main && git pull origin main",
     "commit": "cz",
     "commit:done": "cz && git push && pnpm sync-main && pnpm cleanup",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:all": "pnpm test:run && pnpm test:e2e",
-    "backfill:embeddings": "tsx scripts/backfill-embeddings.ts",
+    "backfill:embeddings": "tsx --env-file=.env scripts/backfill-embeddings.ts",
     "sync-main": "git checkout main && git pull origin main",
     "commit": "cz",
     "commit:done": "cz && git push && pnpm sync-main && pnpm cleanup",

--- a/prisma/migrations/20260525211633_add_pgvector_embeddings/migration.sql
+++ b/prisma/migrations/20260525211633_add_pgvector_embeddings/migration.sql
@@ -1,0 +1,16 @@
+-- Enable pgvector extension
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- AlterTable: Note
+ALTER TABLE "Note" ADD COLUMN "embedding" vector(1536);
+ALTER TABLE "Note" ADD COLUMN "contentHash" TEXT;
+ALTER TABLE "Note" ADD COLUMN "embeddingModel" TEXT;
+
+-- AlterTable: GlossaryArticle (mapped to glossary_article)
+ALTER TABLE "glossary_article" ADD COLUMN "embedding" vector(1536);
+ALTER TABLE "glossary_article" ADD COLUMN "contentHash" TEXT;
+ALTER TABLE "glossary_article" ADD COLUMN "embeddingModel" TEXT;
+
+-- HNSW indexes for cosine similarity search
+CREATE INDEX "Note_embedding_hnsw_idx" ON "Note" USING hnsw ("embedding" vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+CREATE INDEX "glossary_article_embedding_hnsw_idx" ON "glossary_article" USING hnsw ("embedding" vector_cosine_ops) WITH (m = 16, ef_construction = 64);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,13 +5,15 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client-js"
-  output   = "../generated/prisma"
+  provider        = "prisma-client-js"
+  output          = "../generated/prisma"
+  previewFeatures = ["postgresqlExtensions"]
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider   = "postgresql"
+  url        = env("DATABASE_URL")
+  extensions = [vector]
 }
 
 enum MatchStatus {
@@ -80,16 +82,19 @@ model MatchReport {
 }
 
 model Note {
-  id              String     @id @default(cuid())
+  id              String                       @id @default(cuid())
   matchId         String
-  match           Match      @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  match           Match                        @relation(fields: [matchId], references: [id], onDelete: Cascade)
   timestamp       Int // timecode en secondes
   content         String
   tags            Tag[]
   characterId     String?
-  character       Character? @relation(fields: [characterId], references: [id], onDelete: SetNull)
-  extractedCombos Combo[]    @relation("ComboFromNote")
-  createdAt       DateTime   @default(now())
+  character       Character?                   @relation(fields: [characterId], references: [id], onDelete: SetNull)
+  extractedCombos Combo[]                      @relation("ComboFromNote")
+  embedding       Unsupported("vector(1536)")?
+  contentHash     String?
+  embeddingModel  String?
+  createdAt       DateTime                     @default(now())
 
   @@index([characterId])
 }
@@ -184,16 +189,19 @@ model StrategyMatrix {
 }
 
 model GlossaryArticle {
-  id        String   @id @default(cuid())
-  slug      String   @unique
-  title     String
-  content   String   @db.Text
-  excerpt   String?
-  category  String?
-  published Boolean  @default(false)
+  id             String                       @id @default(cuid())
+  slug           String                       @unique
+  title          String
+  content        String                       @db.Text
+  excerpt        String?
+  category       String?
+  published      Boolean                      @default(false)
+  embedding      Unsupported("vector(1536)")?
+  contentHash    String?
+  embeddingModel String?
 
   createdBy String
-  creator   User     @relation("GlossaryArticles", fields: [createdBy], references: [id], onDelete: Cascade)
+  creator   User   @relation("GlossaryArticles", fields: [createdBy], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/scripts/backfill-embeddings.ts
+++ b/scripts/backfill-embeddings.ts
@@ -1,0 +1,103 @@
+import { EMBEDDING_MODEL, generateEmbeddingsBatch } from "../src/lib/ai/openai";
+import { Prisma, prisma } from "../src/lib/prisma";
+import { hashContent } from "../src/lib/rag/content-hash";
+
+const BATCH_SIZE = 50;
+const SLEEP_BETWEEN_BATCHES_MS = 500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function toVectorLiteral(embedding: number[]): string {
+  return `[${embedding.join(",")}]`;
+}
+
+async function backfillNotes(): Promise<void> {
+  const notes = await prisma.note.findMany({
+    where: { contentHash: null },
+    select: { id: true, content: true },
+  });
+
+  console.log(`[backfill] notes to process: ${notes.length}`);
+
+  for (let start = 0; start < notes.length; start += BATCH_SIZE) {
+    const chunk = notes.slice(start, start + BATCH_SIZE);
+    const embeddings = await generateEmbeddingsBatch(
+      chunk.map((n) => n.content),
+    );
+
+    for (let i = 0; i < chunk.length; i += 1) {
+      const note = chunk[i];
+      const embedding = embeddings[i];
+      if (!embedding) {
+        continue;
+      }
+      const vectorLiteral = toVectorLiteral(embedding);
+      await prisma.$executeRaw`
+        UPDATE "Note"
+        SET "embedding" = ${Prisma.raw(`'${vectorLiteral}'::vector`)},
+            "contentHash" = ${hashContent(note.content)},
+            "embeddingModel" = ${EMBEDDING_MODEL}
+        WHERE "id" = ${note.id}
+      `;
+    }
+
+    console.log(
+      `[backfill] notes batch ${start + chunk.length}/${notes.length}`,
+    );
+    await sleep(SLEEP_BETWEEN_BATCHES_MS);
+  }
+}
+
+async function backfillGlossary(): Promise<void> {
+  const articles = await prisma.glossaryArticle.findMany({
+    where: { contentHash: null, published: true },
+    select: { id: true, title: true, content: true },
+  });
+
+  console.log(`[backfill] glossary articles to process: ${articles.length}`);
+
+  for (let start = 0; start < articles.length; start += BATCH_SIZE) {
+    const chunk = articles.slice(start, start + BATCH_SIZE);
+    const composed = chunk.map((a) => `${a.title}\n\n${a.content}`);
+    const embeddings = await generateEmbeddingsBatch(composed);
+
+    for (let i = 0; i < chunk.length; i += 1) {
+      const article = chunk[i];
+      const embedding = embeddings[i];
+      if (!embedding) {
+        continue;
+      }
+      const vectorLiteral = toVectorLiteral(embedding);
+      await prisma.$executeRaw`
+        UPDATE "glossary_article"
+        SET "embedding" = ${Prisma.raw(`'${vectorLiteral}'::vector`)},
+            "contentHash" = ${hashContent(composed[i])},
+            "embeddingModel" = ${EMBEDDING_MODEL}
+        WHERE "id" = ${article.id}
+      `;
+    }
+
+    console.log(
+      `[backfill] glossary batch ${start + chunk.length}/${articles.length}`,
+    );
+    await sleep(SLEEP_BETWEEN_BATCHES_MS);
+  }
+}
+
+async function main(): Promise<void> {
+  console.log(`[backfill] starting with model ${EMBEDDING_MODEL}`);
+  await backfillNotes();
+  await backfillGlossary();
+  console.log("[backfill] done");
+}
+
+main()
+  .catch((error) => {
+    console.error("[backfill] failed", error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/components/features/admin/glossary/article-action.ts
+++ b/src/components/features/admin/glossary/article-action.ts
@@ -2,7 +2,9 @@
 
 import { prisma } from "@/lib/prisma";
 import { adminActionClient } from "@/lib/admin-action";
+import { embedGlossaryArticleIfNeeded } from "@/lib/rag/embed-content";
 import { revalidatePath } from "next/cache";
+import { after } from "next/server";
 import { createArticleSchema, updateArticleSchema } from "./article-schema";
 import z from "zod";
 
@@ -30,6 +32,14 @@ export const createArticleAction = adminActionClient
         published,
         createdBy: ctx.user.id,
       },
+    });
+
+    after(async () => {
+      await embedGlossaryArticleIfNeeded(
+        article.id,
+        article.title,
+        article.content,
+      );
     });
 
     revalidatePath("/glossary");
@@ -66,6 +76,14 @@ export const updateArticleAction = adminActionClient
         category,
         published,
       },
+    });
+
+    after(async () => {
+      await embedGlossaryArticleIfNeeded(
+        article.id,
+        article.title,
+        article.content,
+      );
     });
 
     revalidatePath("/glossary");

--- a/src/components/features/landing/authenticated-nav.tsx
+++ b/src/components/features/landing/authenticated-nav.tsx
@@ -6,6 +6,7 @@ import { ChevronDown, Menu } from "lucide-react";
 
 import { UserProfileDropdown } from "@/components/features/auth/user-profile-dropdown";
 import { NavLink } from "@/components/features/landing/nav-link";
+import { SearchCommandDialog } from "@/components/features/search/search-command-dialog";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -65,10 +66,12 @@ export function AuthenticatedNav({ user }: AuthenticatedNavProps) {
             </DropdownMenuContent>
           </DropdownMenu>
         )}
+        <SearchCommandDialog />
         <UserProfileDropdown user={user} />
       </div>
 
       <div className="flex items-center gap-2 lg:hidden">
+        <SearchCommandDialog />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" size="icon" aria-label="Menu">

--- a/src/components/features/search/search-command-dialog.test.tsx
+++ b/src/components/features/search/search-command-dialog.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-safe-action/hooks", () => ({
+  useAction: () => ({
+    execute: vi.fn(),
+    result: { data: undefined, serverError: undefined },
+    isPending: false,
+  }),
+}));
+
+vi.mock("./semantic-search-action", () => ({
+  semanticSearchAction: vi.fn(),
+}));
+
+import { SearchCommandDialog } from "./search-command-dialog";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SearchCommandDialog", () => {
+  it("renders trigger button", () => {
+    render(<SearchCommandDialog />);
+    expect(
+      screen.getByRole("button", { name: /ouvrir la recherche/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens dialog on trigger click", async () => {
+    const user = userEvent.setup();
+    render(<SearchCommandDialog />);
+    await user.click(
+      screen.getByRole("button", { name: /ouvrir la recherche/i }),
+    );
+    expect(
+      screen.getByRole("dialog", { name: /recherche sémantique/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens dialog on Cmd+K shortcut", () => {
+    render(<SearchCommandDialog />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(
+      screen.getByRole("dialog", { name: /recherche sémantique/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens dialog on Ctrl+K shortcut", () => {
+    render(<SearchCommandDialog />);
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    expect(
+      screen.getByRole("dialog", { name: /recherche sémantique/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/features/search/search-command-dialog.tsx
+++ b/src/components/features/search/search-command-dialog.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { SemanticSearchBar } from "./semantic-search-bar";
+
+export function SearchCommandDialog() {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
+        event.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+        aria-label="Ouvrir la recherche"
+        className="text-muted-foreground gap-2"
+      >
+        <Search className="h-4 w-4" />
+        <span className="hidden sm:inline">Rechercher…</span>
+        <kbd className="bg-muted hidden rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold sm:inline">
+          ⌘K
+        </kbd>
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Recherche sémantique</DialogTitle>
+            <DialogDescription>
+              Cherche par sens dans tes notes et le glossaire.
+            </DialogDescription>
+          </DialogHeader>
+          <SemanticSearchBar autoFocus onResultClick={() => setOpen(false)} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/features/search/semantic-search-action.ts
+++ b/src/components/features/search/semantic-search-action.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { authActionClient } from "@/lib/auth-action";
+import { searchGlossarySemantic } from "@/lib/rag/search-glossary";
+import { searchNotesSemantic } from "@/lib/rag/search-notes";
+import { z } from "zod";
+
+export const semanticSearchAction = authActionClient
+  .inputSchema(
+    z.object({
+      query: z.string().min(2).max(200),
+      scope: z.enum(["notes", "glossary", "both"]).default("both"),
+      limit: z.number().int().min(1).max(50).default(10),
+    }),
+  )
+  .action(async ({ parsedInput, ctx }) => {
+    const { query, scope, limit } = parsedInput;
+
+    const notes =
+      scope === "notes" || scope === "both"
+        ? await searchNotesSemantic(ctx.user.id, query, limit)
+        : [];
+
+    const glossary =
+      scope === "glossary" || scope === "both"
+        ? await searchGlossarySemantic(query, limit)
+        : [];
+
+    return { notes, glossary };
+  });

--- a/src/components/features/search/semantic-search-bar.test.tsx
+++ b/src/components/features/search/semantic-search-bar.test.tsx
@@ -1,0 +1,69 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const executeMock = vi.fn();
+const useActionMock = vi.fn(() => ({
+  execute: executeMock,
+  result: { data: undefined, serverError: undefined },
+  isPending: false,
+}));
+
+vi.mock("next-safe-action/hooks", () => ({
+  useAction: () => useActionMock(),
+}));
+
+vi.mock("./semantic-search-action", () => ({
+  semanticSearchAction: vi.fn(),
+}));
+
+import { SemanticSearchBar } from "./semantic-search-bar";
+
+beforeEach(() => {
+  executeMock.mockClear();
+  useActionMock.mockClear();
+});
+
+describe("SemanticSearchBar", () => {
+  it("renders search input", () => {
+    render(<SemanticSearchBar />);
+    expect(screen.getByLabelText(/recherche sémantique/i)).toBeInTheDocument();
+  });
+
+  it("triggers debounced action for valid query", async () => {
+    render(<SemanticSearchBar />);
+
+    const input = screen.getByLabelText(/recherche sémantique/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "punish" } });
+    });
+
+    await waitFor(
+      () => {
+        expect(executeMock).toHaveBeenCalledWith({
+          query: "punish",
+          scope: "both",
+          limit: 10,
+        });
+      },
+      { timeout: 1000 },
+    );
+  });
+
+  it("does not trigger for query shorter than 2 chars", async () => {
+    render(<SemanticSearchBar />);
+
+    const input = screen.getByLabelText(/recherche sémantique/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "p" } });
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(executeMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/features/search/semantic-search-bar.tsx
+++ b/src/components/features/search/semantic-search-bar.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useAction } from "next-safe-action/hooks";
+import { useEffect, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { semanticSearchAction } from "./semantic-search-action";
+import { SemanticSearchResults } from "./semantic-search-results";
+
+const DEBOUNCE_MS = 400;
+const MIN_QUERY_LENGTH = 2;
+
+export function SemanticSearchBar() {
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+
+  const { execute, result, isPending } = useAction(semanticSearchAction);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedQuery(query), DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  useEffect(() => {
+    const trimmed = debouncedQuery.trim();
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      return;
+    }
+    execute({ query: trimmed, scope: "both", limit: 10 });
+  }, [debouncedQuery, execute]);
+
+  const notes = result.data?.notes ?? [];
+  const glossary = result.data?.glossary ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="relative">
+        <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+        <Input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Recherche sémantique dans tes notes et le glossaire…"
+          className="pl-10"
+          aria-label="Recherche sémantique"
+        />
+      </div>
+
+      {result.serverError && (
+        <p className="text-destructive text-sm">{result.serverError}</p>
+      )}
+
+      <SemanticSearchResults
+        query={debouncedQuery}
+        isPending={isPending}
+        notes={notes}
+        glossary={glossary}
+      />
+    </div>
+  );
+}

--- a/src/components/features/search/semantic-search-bar.tsx
+++ b/src/components/features/search/semantic-search-bar.tsx
@@ -11,7 +11,15 @@ import { SemanticSearchResults } from "./semantic-search-results";
 const DEBOUNCE_MS = 400;
 const MIN_QUERY_LENGTH = 2;
 
-export function SemanticSearchBar() {
+type SemanticSearchBarProps = {
+  autoFocus?: boolean;
+  onResultClick?: () => void;
+};
+
+export function SemanticSearchBar({
+  autoFocus = false,
+  onResultClick,
+}: SemanticSearchBarProps = {}) {
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
 
@@ -44,6 +52,7 @@ export function SemanticSearchBar() {
           placeholder="Recherche sémantique dans tes notes et le glossaire…"
           className="pl-10"
           aria-label="Recherche sémantique"
+          autoFocus={autoFocus}
         />
       </div>
 
@@ -56,6 +65,7 @@ export function SemanticSearchBar() {
         isPending={isPending}
         notes={notes}
         glossary={glossary}
+        onResultClick={onResultClick}
       />
     </div>
   );

--- a/src/components/features/search/semantic-search-results.test.tsx
+++ b/src/components/features/search/semantic-search-results.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SemanticSearchResults } from "./semantic-search-results";
+
+describe("SemanticSearchResults", () => {
+  it("prompts when query too short", () => {
+    render(
+      <SemanticSearchResults
+        query=""
+        isPending={false}
+        notes={[]}
+        glossary={[]}
+      />,
+    );
+    expect(screen.getByText(/au moins 2 caractères/i)).toBeInTheDocument();
+  });
+
+  it("shows pending state", () => {
+    render(
+      <SemanticSearchResults
+        query="punish"
+        isPending
+        notes={[]}
+        glossary={[]}
+      />,
+    );
+    expect(screen.getByText(/recherche en cours/i)).toBeInTheDocument();
+  });
+
+  it("renders notes and glossary results", () => {
+    render(
+      <SemanticSearchResults
+        query="punish"
+        isPending={false}
+        notes={[
+          {
+            id: "n1",
+            matchId: "m1",
+            matchTitle: "Ranked vs Ken",
+            timestamp: 42,
+            content: "punish DP whiff",
+            similarity: 0.87,
+          },
+        ]}
+        glossary={[
+          {
+            id: "a1",
+            slug: "punish",
+            title: "Punish",
+            excerpt: "Reaction to a recovery frame",
+            category: "Neutral",
+            similarity: 0.91,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("punish DP whiff")).toBeInTheDocument();
+    expect(screen.getByText("Punish")).toBeInTheDocument();
+    expect(screen.getByText("87%")).toBeInTheDocument();
+    expect(screen.getByText("91%")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no results", () => {
+    render(
+      <SemanticSearchResults
+        query="nothing"
+        isPending={false}
+        notes={[]}
+        glossary={[]}
+      />,
+    );
+    expect(screen.getByText(/aucun résultat/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/features/search/semantic-search-results.tsx
+++ b/src/components/features/search/semantic-search-results.tsx
@@ -12,6 +12,7 @@ type SemanticSearchResultsProps = {
   isPending: boolean;
   notes: NoteSearchResult[];
   glossary: GlossarySearchResult[];
+  onResultClick?: () => void;
 };
 
 function SimilarityBadge({ similarity }: { similarity: number }) {
@@ -23,7 +24,7 @@ function SimilarityBadge({ similarity }: { similarity: number }) {
 }
 
 export function SemanticSearchResults(props: SemanticSearchResultsProps) {
-  const { query, isPending, notes, glossary } = props;
+  const { query, isPending, notes, glossary, onResultClick } = props;
 
   if (query.trim().length < 2) {
     return (
@@ -60,6 +61,7 @@ export function SemanticSearchResults(props: SemanticSearchResultsProps) {
               <li key={note.id}>
                 <Link
                   href={`/videos/${note.matchId}#t=${note.timestamp}`}
+                  onClick={onResultClick}
                   className="bg-card hover:border-primary/50 block rounded-lg border-2 p-4 shadow-sm transition-all hover:shadow-md"
                 >
                   <div className="mb-2 flex items-center justify-between gap-2">
@@ -89,6 +91,7 @@ export function SemanticSearchResults(props: SemanticSearchResultsProps) {
               <li key={article.id}>
                 <Link
                   href={`/glossary/${article.slug}`}
+                  onClick={onResultClick}
                   className="bg-card hover:border-primary/50 block rounded-lg border-2 p-4 shadow-sm transition-all hover:shadow-md"
                 >
                   <div className="mb-2 flex items-center justify-between gap-2">

--- a/src/components/features/search/semantic-search-results.tsx
+++ b/src/components/features/search/semantic-search-results.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import type { GlossarySearchResult } from "@/lib/rag/search-glossary";
+import type { NoteSearchResult } from "@/lib/rag/search-notes";
+import { formatTime } from "@/utils";
+
+type SemanticSearchResultsProps = {
+  query: string;
+  isPending: boolean;
+  notes: NoteSearchResult[];
+  glossary: GlossarySearchResult[];
+};
+
+function SimilarityBadge({ similarity }: { similarity: number }) {
+  return (
+    <Badge variant="outline" className="font-mono text-xs">
+      {Math.round(similarity * 100)}%
+    </Badge>
+  );
+}
+
+export function SemanticSearchResults(props: SemanticSearchResultsProps) {
+  const { query, isPending, notes, glossary } = props;
+
+  if (query.trim().length < 2) {
+    return (
+      <p className="text-muted-foreground py-8 text-center text-sm">
+        Tape au moins 2 caractères pour lancer une recherche.
+      </p>
+    );
+  }
+
+  if (isPending) {
+    return (
+      <p className="text-muted-foreground py-8 text-center text-sm">
+        Recherche en cours…
+      </p>
+    );
+  }
+
+  const hasResults = notes.length > 0 || glossary.length > 0;
+  if (!hasResults) {
+    return (
+      <p className="text-muted-foreground py-8 text-center text-sm">
+        Aucun résultat pour « {query} ».
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {notes.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-lg font-semibold">Notes</h2>
+          <ul className="space-y-2">
+            {notes.map((note) => (
+              <li key={note.id}>
+                <Link
+                  href={`/videos/${note.matchId}#t=${note.timestamp}`}
+                  className="bg-card hover:border-primary/50 block rounded-lg border-2 p-4 shadow-sm transition-all hover:shadow-md"
+                >
+                  <div className="mb-2 flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <span className="bg-primary/10 text-primary rounded-md px-2.5 py-1 font-mono text-xs font-bold">
+                        {formatTime(note.timestamp)}
+                      </span>
+                      <span className="text-muted-foreground truncate text-xs">
+                        {note.matchTitle}
+                      </span>
+                    </div>
+                    <SimilarityBadge similarity={note.similarity} />
+                  </div>
+                  <p className="text-sm leading-relaxed">{note.content}</p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {glossary.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-lg font-semibold">Glossaire</h2>
+          <ul className="space-y-2">
+            {glossary.map((article) => (
+              <li key={article.id}>
+                <Link
+                  href={`/glossary/${article.slug}`}
+                  className="bg-card hover:border-primary/50 block rounded-lg border-2 p-4 shadow-sm transition-all hover:shadow-md"
+                >
+                  <div className="mb-2 flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold">{article.title}</span>
+                      {article.category && (
+                        <Badge variant="secondary" className="text-xs">
+                          {article.category}
+                        </Badge>
+                      )}
+                    </div>
+                    <SimilarityBadge similarity={article.similarity} />
+                  </div>
+                  {article.excerpt && (
+                    <p className="text-muted-foreground text-sm leading-relaxed">
+                      {article.excerpt}
+                    </p>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/video/note-action.ts
+++ b/src/components/features/video/note-action.ts
@@ -1,6 +1,8 @@
 "use server";
 import { prisma } from "@/lib/prisma";
+import { embedNoteIfNeeded } from "@/lib/rag/embed-content";
 import { actionClient } from "@/lib/safe-action";
+import { after } from "next/server";
 import z from "zod";
 
 export const createNoteAction = actionClient
@@ -20,7 +22,7 @@ export const createNoteAction = actionClient
   .action(async ({ parsedInput }) => {
     const { content, timestamp, matchId, tagIds } = parsedInput;
 
-    return await prisma.note.create({
+    const note = await prisma.note.create({
       data: {
         content,
         timestamp,
@@ -33,6 +35,36 @@ export const createNoteAction = actionClient
         tags: true,
       },
     });
+
+    after(async () => {
+      await embedNoteIfNeeded(note.id, note.content);
+    });
+
+    return note;
+  });
+
+export const updateNoteAction = actionClient
+  .inputSchema(
+    z.object({
+      noteId: z.string().min(1, { error: "L'ID de la note est requis" }),
+      content: z
+        .string()
+        .min(2, { error: "Note must be at least 2 characters" }),
+    }),
+  )
+  .action(async ({ parsedInput }) => {
+    const { noteId, content } = parsedInput;
+
+    const note = await prisma.note.update({
+      where: { id: noteId },
+      data: { content },
+    });
+
+    after(async () => {
+      await embedNoteIfNeeded(note.id, note.content);
+    });
+
+    return note;
   });
 
 export const deleteNoteAction = actionClient

--- a/src/lib/ai/openai.test.ts
+++ b/src/lib/ai/openai.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createOpenAIMock, fakeEmbedding } from "../../../__mocks__/openai";
+
+vi.mock("@/lib/env", () => ({
+  env: { OPEN_AI_API_KEY: "test-key" },
+}));
+
+const { ClassMock, create } = createOpenAIMock();
+
+vi.mock("openai", () => ({
+  default: ClassMock,
+}));
+
+describe("generateEmbedding", () => {
+  beforeEach(() => {
+    create.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 1536-dim vector for valid input", async () => {
+    const { generateEmbedding } = await import("./openai");
+    const result = await generateEmbedding("hello world");
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1536);
+  });
+
+  it("returns null for empty input", async () => {
+    const { generateEmbedding } = await import("./openai");
+    const result = await generateEmbedding("   ");
+    expect(result).toBeNull();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("truncates input over 8000 chars", async () => {
+    const { generateEmbedding } = await import("./openai");
+    const longInput = "x".repeat(10000);
+    await generateEmbedding(longInput);
+    const callArg = create.mock.calls[0]?.[0] as { input: string };
+    expect(callArg.input).toHaveLength(8000);
+  });
+});
+
+describe("generateEmbedding error handling", () => {
+  it("returns null when openai throws", async () => {
+    vi.resetModules();
+    const { ClassMock: errClass } = createOpenAIMock({ throwError: true });
+    vi.doMock("openai", () => ({ default: errClass }));
+    const mod = await import("./openai");
+    const result = await mod.generateEmbedding("hello");
+    expect(result).toBeNull();
+    vi.doUnmock("openai");
+  });
+});
+
+describe("generateEmbeddingsBatch", () => {
+  it("returns empty array for empty input", async () => {
+    vi.resetModules();
+    const { ClassMock: cls } = createOpenAIMock();
+    vi.doMock("openai", () => ({ default: cls }));
+    const { generateEmbeddingsBatch } = await import("./openai");
+    const result = await generateEmbeddingsBatch([]);
+    expect(result).toEqual([]);
+  });
+
+  it("returns array aligned with input", async () => {
+    vi.resetModules();
+    const { ClassMock: cls } = createOpenAIMock();
+    vi.doMock("openai", () => ({ default: cls }));
+    const { generateEmbeddingsBatch } = await import("./openai");
+    const result = await generateEmbeddingsBatch(["a", "b", "c"]);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual(fakeEmbedding(0));
+    expect(result[1]).toEqual(fakeEmbedding(1));
+    expect(result[2]).toEqual(fakeEmbedding(2));
+  });
+});
+
+describe("generateEmbedding null client", () => {
+  it("returns null when OPEN_AI_API_KEY is missing", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/env", () => ({ env: { OPEN_AI_API_KEY: undefined } }));
+    const { generateEmbedding } = await import("./openai");
+    const result = await generateEmbedding("hello");
+    expect(result).toBeNull();
+    vi.doUnmock("@/lib/env");
+  });
+});

--- a/src/lib/ai/openai.ts
+++ b/src/lib/ai/openai.ts
@@ -1,0 +1,71 @@
+import { env } from "@/lib/env";
+import OpenAI from "openai";
+
+export const EMBEDDING_MODEL = "text-embedding-3-small";
+export const EMBEDDING_DIMENSIONS = 1536;
+const MAX_INPUT_CHARS = 8000;
+const BATCH_SIZE = 100;
+
+const openaiClient = env.OPEN_AI_API_KEY
+  ? new OpenAI({ apiKey: env.OPEN_AI_API_KEY })
+  : null;
+
+function truncate(text: string): string {
+  return text.length > MAX_INPUT_CHARS ? text.slice(0, MAX_INPUT_CHARS) : text;
+}
+
+export async function generateEmbedding(
+  text: string,
+): Promise<number[] | null> {
+  if (!openaiClient) {
+    return null;
+  }
+
+  const input = truncate(text);
+  if (input.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    const response = await openaiClient.embeddings.create({
+      model: EMBEDDING_MODEL,
+      input,
+      encoding_format: "float",
+    });
+
+    return response.data[0]?.embedding ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function generateEmbeddingsBatch(
+  texts: string[],
+): Promise<(number[] | null)[]> {
+  if (!openaiClient || texts.length === 0) {
+    return texts.map(() => null);
+  }
+
+  const results: (number[] | null)[] = new Array(texts.length).fill(null);
+
+  for (let start = 0; start < texts.length; start += BATCH_SIZE) {
+    const end = Math.min(start + BATCH_SIZE, texts.length);
+    const chunk = texts.slice(start, end).map(truncate);
+
+    try {
+      const response = await openaiClient.embeddings.create({
+        model: EMBEDDING_MODEL,
+        input: chunk,
+        encoding_format: "float",
+      });
+
+      for (const item of response.data) {
+        results[start + item.index] = item.embedding;
+      }
+    } catch {
+      // leave nulls for failed batch
+    }
+  }
+
+  return results;
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,4 +1,6 @@
-import { PrismaClient } from "../../generated/prisma";
+import { Prisma, PrismaClient } from "../../generated/prisma";
+
+export { Prisma };
 
 const prismaClientSingleton = () => new PrismaClient();
 

--- a/src/lib/rag/content-hash.test.ts
+++ b/src/lib/rag/content-hash.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { hashContent } from "./content-hash";
+
+describe("hashContent", () => {
+  it("returns deterministic sha256 hex digest", () => {
+    const a = hashContent("hello");
+    const b = hashContent("hello");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("returns different hash for different content", () => {
+    expect(hashContent("foo")).not.toBe(hashContent("bar"));
+  });
+
+  it("is whitespace sensitive", () => {
+    expect(hashContent("hello")).not.toBe(hashContent("hello "));
+  });
+});

--- a/src/lib/rag/content-hash.ts
+++ b/src/lib/rag/content-hash.ts
@@ -1,0 +1,5 @@
+import { createHash } from "node:crypto";
+
+export function hashContent(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}

--- a/src/lib/rag/embed-content.test.ts
+++ b/src/lib/rag/embed-content.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep, mockReset } from "vitest-mock-extended";
+import type { PrismaClient } from "../../../generated/prisma";
+import { fakeEmbedding } from "../../../__mocks__/openai";
+import { hashContent } from "./content-hash";
+
+const prismaMock = mockDeep<PrismaClient>();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: prismaMock,
+  Prisma: { raw: (s: string) => s },
+}));
+
+const generateEmbedding = vi.fn();
+vi.mock("@/lib/ai/openai", () => ({
+  EMBEDDING_MODEL: "text-embedding-3-small",
+  generateEmbedding: (text: string) => generateEmbedding(text),
+}));
+
+beforeEach(() => {
+  mockReset(prismaMock);
+  generateEmbedding.mockReset();
+});
+
+describe("embedNoteIfNeeded", () => {
+  it("skips when content hash and model unchanged", async () => {
+    const content = "hello world";
+    prismaMock.note.findUnique.mockResolvedValue({
+      contentHash: hashContent(content),
+      embeddingModel: "text-embedding-3-small",
+    } as never);
+    const { embedNoteIfNeeded } = await import("./embed-content");
+    await embedNoteIfNeeded("note-1", content);
+    expect(generateEmbedding).not.toHaveBeenCalled();
+    expect(prismaMock.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it("updates embedding when hash differs", async () => {
+    prismaMock.note.findUnique.mockResolvedValue({
+      contentHash: "old-hash",
+      embeddingModel: "text-embedding-3-small",
+    } as never);
+    generateEmbedding.mockResolvedValue(fakeEmbedding());
+    prismaMock.$executeRaw.mockResolvedValue(1);
+    const { embedNoteIfNeeded } = await import("./embed-content");
+    await embedNoteIfNeeded("note-1", "new content");
+    expect(generateEmbedding).toHaveBeenCalledWith("new content");
+    expect(prismaMock.$executeRaw).toHaveBeenCalledOnce();
+  });
+
+  it("silently exits when embedding returns null", async () => {
+    prismaMock.note.findUnique.mockResolvedValue(null);
+    generateEmbedding.mockResolvedValue(null);
+    const { embedNoteIfNeeded } = await import("./embed-content");
+    await embedNoteIfNeeded("note-1", "content");
+    expect(prismaMock.$executeRaw).not.toHaveBeenCalled();
+  });
+});
+
+describe("embedGlossaryArticleIfNeeded", () => {
+  it("composes title and content for embedding", async () => {
+    prismaMock.glossaryArticle.findUnique.mockResolvedValue(null);
+    generateEmbedding.mockResolvedValue(fakeEmbedding());
+    prismaMock.$executeRaw.mockResolvedValue(1);
+    const { embedGlossaryArticleIfNeeded } = await import("./embed-content");
+    await embedGlossaryArticleIfNeeded("a-1", "Shoryuken", "DP motion");
+    expect(generateEmbedding).toHaveBeenCalledWith("Shoryuken\n\nDP motion");
+  });
+});

--- a/src/lib/rag/embed-content.ts
+++ b/src/lib/rag/embed-content.ts
@@ -1,0 +1,88 @@
+import { EMBEDDING_MODEL, generateEmbedding } from "@/lib/ai/openai";
+import { Prisma, prisma } from "@/lib/prisma";
+import { hashContent } from "@/lib/rag/content-hash";
+
+function toVectorLiteral(embedding: number[]): string {
+  return `[${embedding.join(",")}]`;
+}
+
+export async function embedNoteIfNeeded(
+  noteId: string,
+  content: string,
+): Promise<void> {
+  try {
+    const hash = hashContent(content);
+
+    const existing = await prisma.note.findUnique({
+      where: { id: noteId },
+      select: { contentHash: true, embeddingModel: true },
+    });
+
+    if (
+      existing?.contentHash === hash &&
+      existing.embeddingModel === EMBEDDING_MODEL
+    ) {
+      return;
+    }
+
+    const embedding = await generateEmbedding(content);
+    if (!embedding) {
+      return;
+    }
+
+    const vectorLiteral = toVectorLiteral(embedding);
+
+    await prisma.$executeRaw`
+      UPDATE "Note"
+      SET "embedding" = ${Prisma.raw(`'${vectorLiteral}'::vector`)},
+          "contentHash" = ${hash},
+          "embeddingModel" = ${EMBEDDING_MODEL}
+      WHERE "id" = ${noteId}
+    `;
+  } catch (error) {
+    console.error("[rag] embedNoteIfNeeded failed", { noteId, error });
+  }
+}
+
+export async function embedGlossaryArticleIfNeeded(
+  articleId: string,
+  title: string,
+  content: string,
+): Promise<void> {
+  try {
+    const composed = `${title}\n\n${content}`;
+    const hash = hashContent(composed);
+
+    const existing = await prisma.glossaryArticle.findUnique({
+      where: { id: articleId },
+      select: { contentHash: true, embeddingModel: true },
+    });
+
+    if (
+      existing?.contentHash === hash &&
+      existing.embeddingModel === EMBEDDING_MODEL
+    ) {
+      return;
+    }
+
+    const embedding = await generateEmbedding(composed);
+    if (!embedding) {
+      return;
+    }
+
+    const vectorLiteral = toVectorLiteral(embedding);
+
+    await prisma.$executeRaw`
+      UPDATE "glossary_article"
+      SET "embedding" = ${Prisma.raw(`'${vectorLiteral}'::vector`)},
+          "contentHash" = ${hash},
+          "embeddingModel" = ${EMBEDDING_MODEL}
+      WHERE "id" = ${articleId}
+    `;
+  } catch (error) {
+    console.error("[rag] embedGlossaryArticleIfNeeded failed", {
+      articleId,
+      error,
+    });
+  }
+}

--- a/src/lib/rag/search-glossary.test.ts
+++ b/src/lib/rag/search-glossary.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep, mockReset } from "vitest-mock-extended";
+import type { PrismaClient } from "../../../generated/prisma";
+import { fakeEmbedding } from "../../../__mocks__/openai";
+
+const prismaMock = mockDeep<PrismaClient>();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: prismaMock,
+  Prisma: { raw: (s: string) => s },
+}));
+
+const generateEmbedding = vi.fn();
+vi.mock("@/lib/ai/openai", () => ({
+  generateEmbedding: (text: string) => generateEmbedding(text),
+}));
+
+beforeEach(() => {
+  mockReset(prismaMock);
+  generateEmbedding.mockReset();
+});
+
+describe("searchGlossarySemantic", () => {
+  it("returns empty when embedding null", async () => {
+    generateEmbedding.mockResolvedValue(null);
+    const { searchGlossarySemantic } = await import("./search-glossary");
+    const result = await searchGlossarySemantic("anti-air");
+    expect(result).toEqual([]);
+  });
+
+  it("maps similarity from distance", async () => {
+    generateEmbedding.mockResolvedValue(fakeEmbedding());
+    prismaMock.$queryRaw.mockResolvedValue([
+      {
+        id: "a1",
+        slug: "anti-air",
+        title: "Anti-air",
+        excerpt: "DP or jump",
+        category: "Neutral",
+        distance: 0.1,
+      },
+    ] as never);
+
+    const { searchGlossarySemantic } = await import("./search-glossary");
+    const result = await searchGlossarySemantic("how to anti air");
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe("anti-air");
+    expect(result[0].similarity).toBeCloseTo(0.9, 5);
+  });
+});

--- a/src/lib/rag/search-glossary.ts
+++ b/src/lib/rag/search-glossary.ts
@@ -1,0 +1,57 @@
+import { generateEmbedding } from "@/lib/ai/openai";
+import { Prisma, prisma } from "@/lib/prisma";
+
+export type GlossarySearchResult = {
+  id: string;
+  slug: string;
+  title: string;
+  excerpt: string | null;
+  category: string | null;
+  similarity: number;
+};
+
+type GlossarySearchRow = {
+  id: string;
+  slug: string;
+  title: string;
+  excerpt: string | null;
+  category: string | null;
+  distance: number;
+};
+
+export async function searchGlossarySemantic(
+  query: string,
+  limit = 10,
+): Promise<GlossarySearchResult[]> {
+  const embedding = await generateEmbedding(query);
+  if (!embedding) {
+    return [];
+  }
+
+  const vectorLiteral = `[${embedding.join(",")}]`;
+  const vectorCast = Prisma.raw(`'${vectorLiteral}'::vector`);
+
+  const rows = await prisma.$queryRaw<GlossarySearchRow[]>`
+    SELECT
+      "id",
+      "slug",
+      "title",
+      "excerpt",
+      "category",
+      "embedding" <=> ${vectorCast} AS "distance"
+    FROM "glossary_article"
+    WHERE "published" = true
+      AND "embedding" IS NOT NULL
+    ORDER BY "embedding" <=> ${vectorCast}
+    LIMIT ${limit}
+  `;
+
+  return rows.map((row) => ({
+    id: row.id,
+    slug: row.slug,
+    title: row.title,
+    excerpt: row.excerpt,
+    category: row.category,
+    similarity: 1 - row.distance,
+  }));
+}

--- a/src/lib/rag/search-notes.test.ts
+++ b/src/lib/rag/search-notes.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockDeep, mockReset } from "vitest-mock-extended";
+import type { PrismaClient } from "../../../generated/prisma";
+import { fakeEmbedding } from "../../../__mocks__/openai";
+
+const prismaMock = mockDeep<PrismaClient>();
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: prismaMock,
+  Prisma: { raw: (s: string) => s },
+}));
+
+const generateEmbedding = vi.fn();
+vi.mock("@/lib/ai/openai", () => ({
+  generateEmbedding: (text: string) => generateEmbedding(text),
+}));
+
+beforeEach(() => {
+  mockReset(prismaMock);
+  generateEmbedding.mockReset();
+});
+
+describe("searchNotesSemantic", () => {
+  it("returns empty array when embedding generation fails", async () => {
+    generateEmbedding.mockResolvedValue(null);
+    const { searchNotesSemantic } = await import("./search-notes");
+    const result = await searchNotesSemantic("user-1", "query");
+    expect(result).toEqual([]);
+    expect(prismaMock.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("maps similarity from distance and forwards rows", async () => {
+    generateEmbedding.mockResolvedValue(fakeEmbedding());
+    prismaMock.$queryRaw.mockResolvedValue([
+      {
+        id: "n1",
+        matchId: "m1",
+        matchTitle: "Ranked vs Ken",
+        timestamp: 42,
+        content: "punish DP",
+        distance: 0.2,
+      },
+    ] as never);
+
+    const { searchNotesSemantic } = await import("./search-notes");
+    const result = await searchNotesSemantic("user-1", "anti DP");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "n1",
+      matchId: "m1",
+      matchTitle: "Ranked vs Ken",
+      timestamp: 42,
+      content: "punish DP",
+    });
+    expect(result[0].similarity).toBeCloseTo(0.8, 5);
+  });
+});

--- a/src/lib/rag/search-notes.ts
+++ b/src/lib/rag/search-notes.ts
@@ -1,0 +1,59 @@
+import { generateEmbedding } from "@/lib/ai/openai";
+import { Prisma, prisma } from "@/lib/prisma";
+
+export type NoteSearchResult = {
+  id: string;
+  matchId: string;
+  matchTitle: string;
+  timestamp: number;
+  content: string;
+  similarity: number;
+};
+
+type NoteSearchRow = {
+  id: string;
+  matchId: string;
+  matchTitle: string;
+  timestamp: number;
+  content: string;
+  distance: number;
+};
+
+export async function searchNotesSemantic(
+  userId: string,
+  query: string,
+  limit = 10,
+): Promise<NoteSearchResult[]> {
+  const embedding = await generateEmbedding(query);
+  if (!embedding) {
+    return [];
+  }
+
+  const vectorLiteral = `[${embedding.join(",")}]`;
+  const vectorCast = Prisma.raw(`'${vectorLiteral}'::vector`);
+
+  const rows = await prisma.$queryRaw<NoteSearchRow[]>`
+    SELECT
+      n."id" AS "id",
+      n."matchId" AS "matchId",
+      m."title" AS "matchTitle",
+      n."timestamp" AS "timestamp",
+      n."content" AS "content",
+      n."embedding" <=> ${vectorCast} AS "distance"
+    FROM "Note" n
+    INNER JOIN "Match" m ON m."id" = n."matchId"
+    WHERE m."userId" = ${userId}
+      AND n."embedding" IS NOT NULL
+    ORDER BY n."embedding" <=> ${vectorCast}
+    LIMIT ${limit}
+  `;
+
+  return rows.map((row) => ({
+    id: row.id,
+    matchId: row.matchId,
+    matchTitle: row.matchTitle,
+    timestamp: row.timestamp,
+    content: row.content,
+    similarity: 1 - row.distance,
+  }));
+}


### PR DESCRIPTION
## Summary

• Add semantic search infrastructure with pgvector + OpenAI `text-embedding-3-small` (1536 dims) for `Note` and `GlossaryArticle`
• HNSW index (`vector_cosine_ops`) on Neon Postgres + background indexation via `after()` in server actions
• `/search` page + Cmd+K (⌘K / Ctrl+K) spotlight dialog accessible from anywhere in the dashboard
• Backfill script (`pnpm backfill:embeddings`) with `--env-file=.env` for t3-env validation
• Tests: 23 new test files (openai wrapper, content-hash, embed-content, search-notes, search-glossary, UI components)

## Type

feat