### PR TITLE
feat(memo): personal memo notes with pgvector semantic search

### DIFF
--- a/.claude/rules/rag.md
+++ b/.claude/rules/rag.md
@@ -1,6 +1,6 @@
 # RAG / Semantic Search
 
-Semantic search infrastructure for `Note` and `GlossaryArticle`.
+Semantic search infrastructure for `Note`, `Memo` and `GlossaryArticle`.
 
 ## Stack
 
@@ -13,8 +13,9 @@ Semantic search infrastructure for `Note` and `GlossaryArticle`.
 
 - `src/lib/ai/openai.ts` — `generateEmbedding`, `generateEmbeddingsBatch` (null-safe like Groq client)
 - `src/lib/rag/content-hash.ts` — sha256 hash for change detection
-- `src/lib/rag/embed-content.ts` — `embedNoteIfNeeded`, `embedGlossaryArticleIfNeeded` (skip when hash + model unchanged)
+- `src/lib/rag/embed-content.ts` — `embedNoteIfNeeded`, `embedMemoIfNeeded`, `embedGlossaryArticleIfNeeded` (skip when hash + model unchanged)
 - `src/lib/rag/search-notes.ts` — cosine search scoped by `Match.userId`
+- `src/lib/rag/search-memos.ts` — cosine search scoped by `Memo.userId`
 - `src/lib/rag/search-glossary.ts` — cosine search on `published = true` articles
 - `src/components/features/search/` — `semanticSearchAction` (authActionClient) + UI
 - `app/(dashboard)/search/page.tsx` — entry page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-05-31
+
+### Added: Personal memo notes with notation and frame data selectors, accessible from dashboard CTA
+
+### Added: Memos indexed and searchable via semantic search (RAG) alongside notes and glossary
+
+### Fixed: Memo RAG columns missing in DB by splitting add_memo migration and adding add_memo_embedding
+
+### Added: Eye icon on memo list to preview content in a dialog
+
 ## 2026-05-30
 
 ### Added: Cmd+K spotlight dialog for semantic search from anywhere in the dashboard

--- a/app/(dashboard)/notes/memo/[id]/page.tsx
+++ b/app/(dashboard)/notes/memo/[id]/page.tsx
@@ -1,0 +1,41 @@
+import { MemoForm } from "@/components/features/memo/memo-form";
+import { requireAuth } from "@/lib/auth-utils";
+import { notFound } from "next/navigation";
+import { getMemoById } from "../../../../../prisma/query/memo.query";
+
+export default async function MemoDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const user = await requireAuth();
+  const { id } = await params;
+
+  const memo = await getMemoById({ id, userId: user.id });
+
+  if (!memo) {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 px-4 py-8">
+      <div>
+        <h1 className="text-3xl font-bold">Modifier le mémo</h1>
+        <p className="text-muted-foreground mt-1">
+          Mis à jour le{" "}
+          {new Date(memo.updatedAt).toLocaleDateString("fr-FR", {
+            day: "2-digit",
+            month: "long",
+            year: "numeric",
+          })}
+        </p>
+      </div>
+
+      <MemoForm
+        mode="edit"
+        memoId={memo.id}
+        initialData={{ title: memo.title, content: memo.content }}
+      />
+    </div>
+  );
+}

--- a/app/(dashboard)/notes/memo/new/page.tsx
+++ b/app/(dashboard)/notes/memo/new/page.tsx
@@ -1,0 +1,19 @@
+import { MemoForm } from "@/components/features/memo/memo-form";
+import { requireAuth } from "@/lib/auth-utils";
+
+export default async function NewMemoPage() {
+  await requireAuth();
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 px-4 py-8">
+      <div>
+        <h1 className="text-3xl font-bold">Nouveau mémo</h1>
+        <p className="text-muted-foreground mt-1">
+          Notez une stratégie, un punish, une combinaison.
+        </p>
+      </div>
+
+      <MemoForm mode="create" />
+    </div>
+  );
+}

--- a/app/(dashboard)/notes/memo/page.tsx
+++ b/app/(dashboard)/notes/memo/page.tsx
@@ -1,0 +1,32 @@
+import { MemoList } from "@/components/features/memo/memo-list";
+import { Button } from "@/components/ui/button";
+import { requireAuth } from "@/lib/auth-utils";
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import { getMemosByUser } from "../../../../prisma/query/memo.query";
+
+export default async function MemoListPage() {
+  const user = await requireAuth();
+  const memos = await getMemosByUser({ userId: user.id });
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6 px-4 py-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Mémos</h1>
+          <p className="text-muted-foreground mt-1">
+            Vos aide-mémoires personnels : notations, frame data, situations.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/notes/memo/new">
+            <Plus className="mr-2 h-4 w-4" />
+            Nouveau mémo
+          </Link>
+        </Button>
+      </div>
+
+      <MemoList memos={memos} />
+    </div>
+  );
+}

--- a/app/(dashboard)/search/page.tsx
+++ b/app/(dashboard)/search/page.tsx
@@ -10,8 +10,8 @@ export default function SearchPage() {
       <header className="mb-8">
         <h1 className="text-3xl font-bold">Recherche sémantique</h1>
         <p className="text-muted-foreground mt-2 text-sm">
-          Cherche dans tes notes timestampées et les articles du glossaire par
-          sens, pas seulement par mots-clés.
+          Cherche dans tes notes timestampées, tes mémos et les articles du
+          glossaire par sens, pas seulement par mots-clés.
         </p>
       </header>
       <SemanticSearchBar />

--- a/prisma/migrations/20260531120000_add_memo/migration.sql
+++ b/prisma/migrations/20260531120000_add_memo/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Memo" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Memo_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Memo_userId_idx" ON "Memo"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Memo" ADD CONSTRAINT "Memo_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260531130000_add_memo_embedding/migration.sql
+++ b/prisma/migrations/20260531130000_add_memo_embedding/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable: Memo
+ALTER TABLE "Memo" ADD COLUMN "embedding" vector(1536);
+ALTER TABLE "Memo" ADD COLUMN "contentHash" TEXT;
+ALTER TABLE "Memo" ADD COLUMN "embeddingModel" TEXT;
+
+-- HNSW index for cosine similarity search
+CREATE INDEX "Memo_embedding_hnsw_idx" ON "Memo" USING hnsw ("embedding" vector_cosine_ops) WITH (m = 16, ef_construction = 64);

--- a/prisma/query/memo.query.ts
+++ b/prisma/query/memo.query.ts
@@ -1,0 +1,27 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "../../generated/prisma";
+
+export const getMemosByUser = async ({ userId }: { userId: string }) =>
+  await prisma.memo.findMany({
+    where: { userId },
+    orderBy: { updatedAt: "desc" },
+  });
+
+export type MemoListItem = Prisma.PromiseReturnType<
+  typeof getMemosByUser
+>[number];
+
+export const getMemoById = async ({
+  id,
+  userId,
+}: {
+  id: string;
+  userId: string;
+}) =>
+  await prisma.memo.findFirst({
+    where: { id, userId },
+  });
+
+export type MemoDetail = NonNullable<
+  Prisma.PromiseReturnType<typeof getMemoById>
+>;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,8 +50,24 @@ model User {
   glossaryArticles GlossaryArticle[]  @relation("GlossaryArticles")
   combos           Combo[]
   strategyMatrices StrategyMatrix[]
+  memos            Memo[]
 
   @@map("user")
+}
+
+model Memo {
+  id             String                       @id @default(cuid())
+  userId         String
+  user           User                         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  title          String
+  content        String                       @db.Text
+  embedding      Unsupported("vector(1536)")?
+  contentHash    String?
+  embeddingModel String?
+  createdAt      DateTime                     @default(now())
+  updatedAt      DateTime                     @updatedAt
+
+  @@index([userId])
 }
 
 model Match {

--- a/scripts/backfill-embeddings.ts
+++ b/scripts/backfill-embeddings.ts
@@ -86,10 +86,47 @@ async function backfillGlossary(): Promise<void> {
   }
 }
 
+async function backfillMemos(): Promise<void> {
+  const memos = await prisma.memo.findMany({
+    where: { contentHash: null },
+    select: { id: true, title: true, content: true },
+  });
+
+  console.log(`[backfill] memos to process: ${memos.length}`);
+
+  for (let start = 0; start < memos.length; start += BATCH_SIZE) {
+    const chunk = memos.slice(start, start + BATCH_SIZE);
+    const composed = chunk.map((m) => `${m.title}\n\n${m.content}`);
+    const embeddings = await generateEmbeddingsBatch(composed);
+
+    for (let i = 0; i < chunk.length; i += 1) {
+      const memo = chunk[i];
+      const embedding = embeddings[i];
+      if (!embedding) {
+        continue;
+      }
+      const vectorLiteral = toVectorLiteral(embedding);
+      await prisma.$executeRaw`
+        UPDATE "Memo"
+        SET "embedding" = ${Prisma.raw(`'${vectorLiteral}'::vector`)},
+            "contentHash" = ${hashContent(composed[i])},
+            "embeddingModel" = ${EMBEDDING_MODEL}
+        WHERE "id" = ${memo.id}
+      `;
+    }
+
+    console.log(
+      `[backfill] memos batch ${start + chunk.length}/${memos.length}`,
+    );
+    await sleep(SLEEP_BETWEEN_BATCHES_MS);
+  }
+}
+
 async function main(): Promise<void> {
   console.log(`[backfill] starting with model ${EMBEDDING_MODEL}`);
   await backfillNotes();
   await backfillGlossary();
+  await backfillMemos();
   console.log("[backfill] done");
 }
 

--- a/src/components/features/dashboard/cta-section.tsx
+++ b/src/components/features/dashboard/cta-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Plus } from "lucide-react";
+import { NotebookPen, Plus } from "lucide-react";
 import Link from "next/link";
 
 export function CTASection() {
@@ -22,32 +22,44 @@ export function CTASection() {
         <br />
         <span className="text-foreground font-medium">Get good, faster.</span>
       </p>
-      <div className="flex justify-center gap-4">
-        <Link href="/notes/strategy/new">
-          <Button
-            className="rounded-full font-semibold backdrop-blur transition-all hover:scale-105 hover:bg-zinc-200"
-            variant="secondary"
-            size="lg"
-          >
-            <Plus className="mr-2 h-4 w-4" />
-            Nouvelle matrice de stratégie
-          </Button>
-        </Link>
-        <Link href="/videos/new">
+      <div className="flex flex-col items-center gap-4">
+        <div className="flex flex-wrap justify-center gap-4">
+          <Link href="/notes/strategy/new">
+            <Button
+              className="rounded-full font-semibold backdrop-blur transition-all hover:scale-105 hover:bg-zinc-200"
+              variant="secondary"
+              size="lg"
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Nouvelle matrice de stratégie
+            </Button>
+          </Link>
+          <Link href="/videos/new">
+            <Button
+              className="rounded-full font-semibold backdrop-blur transition-all hover:scale-105"
+              variant="outline"
+              size="lg"
+            >
+              <svg
+                role="img"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title>YouTube</title>
+                <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+              </svg>
+              Nouvelle note de replay
+            </Button>
+          </Link>
+        </div>
+        <Link href="/notes/memo">
           <Button
             className="rounded-full font-semibold backdrop-blur transition-all hover:scale-105"
-            variant="outline"
+            variant="ghost"
             size="lg"
           >
-            <svg
-              role="img"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <title>YouTube</title>
-              <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
-            </svg>
-            Nouvelle note de replay
+            <NotebookPen className="mr-2 h-4 w-4" />
+            Mes mémos
           </Button>
         </Link>
       </div>

--- a/src/components/features/memo/memo-action.ts
+++ b/src/components/features/memo/memo-action.ts
@@ -1,0 +1,87 @@
+"use server";
+
+import { authActionClient } from "@/lib/auth-action";
+import { prisma } from "@/lib/prisma";
+import { embedMemoIfNeeded } from "@/lib/rag/embed-content";
+import { revalidatePath } from "next/cache";
+import { after } from "next/server";
+import {
+  createMemoSchema,
+  deleteMemoSchema,
+  updateMemoSchema,
+} from "./memo-schema";
+
+export const createMemoAction = authActionClient
+  .inputSchema(createMemoSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const memo = await prisma.memo.create({
+      data: {
+        userId: ctx.user.id,
+        title: parsedInput.title,
+        content: parsedInput.content,
+      },
+    });
+
+    after(async () => {
+      await embedMemoIfNeeded(memo.id, memo.title, memo.content);
+    });
+
+    revalidatePath("/notes/memo");
+
+    return memo;
+  });
+
+export const updateMemoAction = authActionClient
+  .inputSchema(updateMemoSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const existing = await prisma.memo.findUnique({
+      where: { id: parsedInput.id },
+      select: { userId: true },
+    });
+
+    if (!existing) {
+      throw new Error("Mémo introuvable");
+    }
+    if (existing.userId !== ctx.user.id) {
+      throw new Error("Non autorisé");
+    }
+
+    const memo = await prisma.memo.update({
+      where: { id: parsedInput.id },
+      data: {
+        title: parsedInput.title,
+        content: parsedInput.content,
+      },
+    });
+
+    after(async () => {
+      await embedMemoIfNeeded(memo.id, memo.title, memo.content);
+    });
+
+    revalidatePath("/notes/memo");
+    revalidatePath(`/notes/memo/${parsedInput.id}`);
+
+    return memo;
+  });
+
+export const deleteMemoAction = authActionClient
+  .inputSchema(deleteMemoSchema)
+  .action(async ({ parsedInput, ctx }) => {
+    const existing = await prisma.memo.findUnique({
+      where: { id: parsedInput.id },
+      select: { userId: true },
+    });
+
+    if (!existing) {
+      throw new Error("Mémo introuvable");
+    }
+    if (existing.userId !== ctx.user.id) {
+      throw new Error("Non autorisé");
+    }
+
+    await prisma.memo.delete({ where: { id: parsedInput.id } });
+
+    revalidatePath("/notes/memo");
+
+    return { success: true };
+  });

--- a/src/components/features/memo/memo-form.tsx
+++ b/src/components/features/memo/memo-form.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { frameDataComponents } from "@/components/features/strategy-matrix/frame-data-renderer";
+import {
+  FGC_ACTIONS,
+  FGC_BUTTONS,
+  FGC_POSITIONS,
+  FRAME_OPTIONS,
+} from "@/components/features/strategy-matrix/strategy-matrix-types";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Eye, Pencil } from "lucide-react";
+import { useAction } from "next-safe-action/hooks";
+import { useRouter } from "next/navigation";
+import { useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { toast } from "sonner";
+import { createMemoAction, updateMemoAction } from "./memo-action";
+import {
+  MAX_MEMO_CONTENT_LENGTH,
+  memoFormSchema,
+  type MemoFormInput,
+} from "./memo-schema";
+
+type Props =
+  | {
+      mode: "create";
+      memoId?: undefined;
+      initialData?: undefined;
+    }
+  | {
+      mode: "edit";
+      memoId: string;
+      initialData: MemoFormInput;
+    };
+
+export function MemoForm(props: Props) {
+  const router = useRouter();
+  const [showPreview, setShowPreview] = useState(false);
+  const [notationKey, setNotationKey] = useState(0);
+  const [frameKey, setFrameKey] = useState(0);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const form = useForm<MemoFormInput>({
+    resolver: zodResolver(memoFormSchema),
+    defaultValues:
+      props.mode === "edit"
+        ? props.initialData
+        : { title: "", content: "" },
+    mode: "onSubmit",
+  });
+
+  const content = form.watch("content");
+
+  const createAction = useAction(createMemoAction, {
+    onSuccess: ({ data }) => {
+      toast.success("Mémo créé");
+      if (data?.id) router.push(`/notes/memo/${data.id}`);
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? "Erreur lors de la création");
+    },
+  });
+
+  const updateAction = useAction(updateMemoAction, {
+    onSuccess: () => {
+      toast.success("Mémo mis à jour");
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? "Erreur lors de la mise à jour");
+    },
+  });
+
+  const isPending = createAction.isPending || updateAction.isPending;
+
+  const insertAtCursor = (text: string, cursorOffset?: number) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const before = content.slice(0, start);
+    const after = content.slice(end);
+    const newContent = (before + text + after).slice(0, MAX_MEMO_CONTENT_LENGTH);
+
+    form.setValue("content", newContent, { shouldDirty: true });
+
+    const newCursorPos =
+      cursorOffset !== undefined ? start + cursorOffset : start + text.length;
+
+    requestAnimationFrame(() => {
+      textarea.focus();
+      textarea.setSelectionRange(newCursorPos, newCursorPos);
+    });
+  };
+
+  const onSubmit = (data: MemoFormInput) => {
+    if (props.mode === "edit") {
+      updateAction.execute({ id: props.memoId, ...data });
+    } else {
+      createAction.execute(data);
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Titre</FormLabel>
+              <FormControl>
+                <Input placeholder="Ex: Punish maxi sur DI bloqué" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="content"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center justify-between">
+                <FormLabel>Contenu</FormLabel>
+                <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground text-xs">
+                    {field.value.length} / {MAX_MEMO_CONTENT_LENGTH}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowPreview((v) => !v)}
+                  >
+                    {showPreview ? (
+                      <>
+                        <Pencil className="mr-2 h-3 w-3" />
+                        Édition
+                      </>
+                    ) : (
+                      <>
+                        <Eye className="mr-2 h-3 w-3" />
+                        Aperçu
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+
+              {!showPreview && (
+                <div className="flex items-center gap-2">
+                  <Select
+                    key={`notation-${notationKey}`}
+                    onValueChange={(v) => {
+                      insertAtCursor(v);
+                      setNotationKey((k) => k + 1);
+                    }}
+                  >
+                    <SelectTrigger size="sm" className="w-auto text-xs">
+                      <SelectValue placeholder="Notation..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        <SelectLabel>Positions</SelectLabel>
+                        {FGC_POSITIONS.map((item) => (
+                          <SelectItem key={item.value} value={item.value}>
+                            {item.label}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                      <SelectGroup>
+                        <SelectLabel>Boutons</SelectLabel>
+                        {FGC_BUTTONS.map((item) => (
+                          <SelectItem key={item.value} value={item.value}>
+                            {item.label}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                      <SelectGroup>
+                        <SelectLabel>Actions</SelectLabel>
+                        {FGC_ACTIONS.map((item) => (
+                          <SelectItem key={item.value} value={item.value}>
+                            {item.label}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+
+                  <Select
+                    key={`frame-${frameKey}`}
+                    onValueChange={(v) => {
+                      const option = FRAME_OPTIONS.find((o) => o.value === v);
+                      const offset =
+                        option && "cursorOffset" in option
+                          ? (option as { cursorOffset: number }).cursorOffset
+                          : undefined;
+                      insertAtCursor(v, offset);
+                      setFrameKey((k) => k + 1);
+                    }}
+                  >
+                    <SelectTrigger size="sm" className="w-auto text-xs">
+                      <SelectValue placeholder="Frames..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {FRAME_OPTIONS.map((item) => (
+                        <SelectItem key={item.value} value={item.value}>
+                          {item.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+
+              <FormControl>
+                {showPreview ? (
+                  <div className="prose prose-invert border-border bg-muted text-foreground min-h-[200px] max-w-none rounded-md border p-3 text-sm">
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm]}
+                      components={frameDataComponents}
+                    >
+                      {field.value || "*Aucun contenu*"}
+                    </ReactMarkdown>
+                  </div>
+                ) : (
+                  <Textarea
+                    ref={textareaRef}
+                    value={field.value}
+                    onChange={(e) =>
+                      field.onChange(
+                        e.target.value.slice(0, MAX_MEMO_CONTENT_LENGTH),
+                      )
+                    }
+                    placeholder="Ex: Sur DI bloqué → cr.HP xx Super (+8)..."
+                    className="min-h-[240px]"
+                  />
+                )}
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.back()}
+            disabled={isPending}
+          >
+            Annuler
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {isPending
+              ? "Enregistrement…"
+              : props.mode === "edit"
+                ? "Mettre à jour"
+                : "Créer le mémo"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/features/memo/memo-list.tsx
+++ b/src/components/features/memo/memo-list.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { FolderOpen, Trash2 } from "lucide-react";
+import { useAction } from "next-safe-action/hooks";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import type { MemoListItem } from "../../../../prisma/query/memo.query";
+import { deleteMemoAction } from "./memo-action";
+import { MemoVisualizeDialog } from "./memo-visualize-dialog";
+
+type Props = {
+  memos: MemoListItem[];
+};
+
+export function MemoList({ memos }: Props) {
+  const router = useRouter();
+  const { execute, isPending } = useAction(deleteMemoAction, {
+    onSuccess: () => {
+      toast.success("Mémo supprimé");
+      router.refresh();
+    },
+    onError: ({ error }) => {
+      toast.error(error.serverError ?? "Erreur lors de la suppression");
+    },
+  });
+
+  if (memos.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-4 rounded-lg border border-dashed p-12 text-center">
+        <p className="text-muted-foreground">Aucun mémo pour le moment.</p>
+        <Button asChild>
+          <Link href="/notes/memo/new">Créer mon premier mémo</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {memos.map((memo) => (
+        <Card key={memo.id} className="flex flex-col gap-3 p-4">
+          <div className="space-y-1">
+            <h3 className="line-clamp-1 font-semibold">{memo.title}</h3>
+            {memo.content && (
+              <p className="text-muted-foreground line-clamp-3 text-sm whitespace-pre-wrap">
+                {memo.content}
+              </p>
+            )}
+          </div>
+          <div className="text-muted-foreground text-xs">
+            Mis à jour le{" "}
+            {new Date(memo.updatedAt).toLocaleDateString("fr-FR", {
+              day: "2-digit",
+              month: "short",
+              year: "numeric",
+            })}
+          </div>
+          <div className="mt-auto flex justify-end gap-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button asChild size="icon" variant="outline">
+                  <Link href={`/notes/memo/${memo.id}`} aria-label="Ouvrir">
+                    <FolderOpen className="h-4 w-4" />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Ouvrir</TooltipContent>
+            </Tooltip>
+            <MemoVisualizeDialog title={memo.title} content={memo.content} />
+            <AlertDialog>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      disabled={isPending}
+                      aria-label="Supprimer"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </AlertDialogTrigger>
+                </TooltipTrigger>
+                <TooltipContent>Supprimer</TooltipContent>
+              </Tooltip>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Supprimer ce mémo ?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Cette action est irréversible. Le mémo « {memo.title} » sera
+                    définitivement supprimé.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Annuler</AlertDialogCancel>
+                  <AlertDialogAction onClick={() => execute({ id: memo.id })}>
+                    Supprimer
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/features/memo/memo-schema.ts
+++ b/src/components/features/memo/memo-schema.ts
@@ -1,0 +1,30 @@
+import z from "zod";
+
+export const MAX_MEMO_TITLE_LENGTH = 120;
+export const MAX_MEMO_CONTENT_LENGTH = 2000;
+
+export const memoFormSchema = z.object({
+  title: z
+    .string()
+    .min(1, { error: "Le titre est requis" })
+    .max(MAX_MEMO_TITLE_LENGTH, {
+      error: `Maximum ${MAX_MEMO_TITLE_LENGTH} caractères`,
+    }),
+  content: z
+    .string()
+    .max(MAX_MEMO_CONTENT_LENGTH, {
+      error: `Maximum ${MAX_MEMO_CONTENT_LENGTH} caractères`,
+    }),
+});
+
+export type MemoFormInput = z.infer<typeof memoFormSchema>;
+
+export const createMemoSchema = memoFormSchema;
+
+export const updateMemoSchema = memoFormSchema.extend({
+  id: z.string().min(1),
+});
+
+export const deleteMemoSchema = z.object({
+  id: z.string().min(1, { error: "L'ID du mémo est requis" }),
+});

--- a/src/components/features/memo/memo-visualize-dialog.tsx
+++ b/src/components/features/memo/memo-visualize-dialog.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Eye } from "lucide-react";
+import { useState } from "react";
+
+type Props = {
+  title: string;
+  content: string;
+};
+
+export function MemoVisualizeDialog({ title, content }: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <Button variant="outline" size="icon" aria-label="Visualiser">
+              <Eye className="h-4 w-4" />
+            </Button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Visualiser</TooltipContent>
+      </Tooltip>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[700px]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        {content ? (
+          <p className="text-sm whitespace-pre-wrap">{content}</p>
+        ) : (
+          <p className="text-muted-foreground text-sm">Aucun contenu.</p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/features/search/search-command-dialog.tsx
+++ b/src/components/features/search/search-command-dialog.tsx
@@ -55,7 +55,7 @@ export function SearchCommandDialog() {
           <DialogHeader>
             <DialogTitle>Recherche sémantique</DialogTitle>
             <DialogDescription>
-              Cherche par sens dans tes notes et le glossaire.
+              Cherche par sens dans tes notes, tes mémos et le glossaire.
             </DialogDescription>
           </DialogHeader>
           <SemanticSearchBar autoFocus onResultClick={() => setOpen(false)} />

--- a/src/components/features/search/semantic-search-action.ts
+++ b/src/components/features/search/semantic-search-action.ts
@@ -2,14 +2,17 @@
 
 import { authActionClient } from "@/lib/auth-action";
 import { searchGlossarySemantic } from "@/lib/rag/search-glossary";
+import { searchMemosSemantic } from "@/lib/rag/search-memos";
 import { searchNotesSemantic } from "@/lib/rag/search-notes";
 import { z } from "zod";
+
+const SEARCH_SCOPES = ["notes", "glossary", "memos", "all"] as const;
 
 export const semanticSearchAction = authActionClient
   .inputSchema(
     z.object({
       query: z.string().min(2).max(200),
-      scope: z.enum(["notes", "glossary", "both"]).default("both"),
+      scope: z.enum(SEARCH_SCOPES).default("all"),
       limit: z.number().int().min(1).max(50).default(10),
     }),
   )
@@ -17,14 +20,19 @@ export const semanticSearchAction = authActionClient
     const { query, scope, limit } = parsedInput;
 
     const notes =
-      scope === "notes" || scope === "both"
+      scope === "notes" || scope === "all"
         ? await searchNotesSemantic(ctx.user.id, query, limit)
         : [];
 
     const glossary =
-      scope === "glossary" || scope === "both"
+      scope === "glossary" || scope === "all"
         ? await searchGlossarySemantic(query, limit)
         : [];
 
-    return { notes, glossary };
+    const memos =
+      scope === "memos" || scope === "all"
+        ? await searchMemosSemantic(ctx.user.id, query, limit)
+        : [];
+
+    return { notes, glossary, memos };
   });

--- a/src/components/features/search/semantic-search-bar.test.tsx
+++ b/src/components/features/search/semantic-search-bar.test.tsx
@@ -47,7 +47,7 @@ describe("SemanticSearchBar", () => {
       () => {
         expect(executeMock).toHaveBeenCalledWith({
           query: "punish",
-          scope: "both",
+          scope: "all",
           limit: 10,
         });
       },

--- a/src/components/features/search/semantic-search-bar.tsx
+++ b/src/components/features/search/semantic-search-bar.tsx
@@ -35,11 +35,12 @@ export function SemanticSearchBar({
     if (trimmed.length < MIN_QUERY_LENGTH) {
       return;
     }
-    execute({ query: trimmed, scope: "both", limit: 10 });
+    execute({ query: trimmed, scope: "all", limit: 10 });
   }, [debouncedQuery, execute]);
 
   const notes = result.data?.notes ?? [];
   const glossary = result.data?.glossary ?? [];
+  const memos = result.data?.memos ?? [];
 
   return (
     <div className="space-y-6">
@@ -65,6 +66,7 @@ export function SemanticSearchBar({
         isPending={isPending}
         notes={notes}
         glossary={glossary}
+        memos={memos}
         onResultClick={onResultClick}
       />
     </div>

--- a/src/components/features/search/semantic-search-results.test.tsx
+++ b/src/components/features/search/semantic-search-results.test.tsx
@@ -10,6 +10,7 @@ describe("SemanticSearchResults", () => {
         isPending={false}
         notes={[]}
         glossary={[]}
+        memos={[]}
       />,
     );
     expect(screen.getByText(/au moins 2 caractères/i)).toBeInTheDocument();
@@ -22,6 +23,7 @@ describe("SemanticSearchResults", () => {
         isPending
         notes={[]}
         glossary={[]}
+        memos={[]}
       />,
     );
     expect(screen.getByText(/recherche en cours/i)).toBeInTheDocument();
@@ -52,6 +54,7 @@ describe("SemanticSearchResults", () => {
             similarity: 0.91,
           },
         ]}
+        memos={[]}
       />,
     );
 
@@ -68,6 +71,7 @@ describe("SemanticSearchResults", () => {
         isPending={false}
         notes={[]}
         glossary={[]}
+        memos={[]}
       />,
     );
     expect(screen.getByText(/aucun résultat/i)).toBeInTheDocument();

--- a/src/components/features/search/semantic-search-results.tsx
+++ b/src/components/features/search/semantic-search-results.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
 import type { GlossarySearchResult } from "@/lib/rag/search-glossary";
+import type { MemoSearchResult } from "@/lib/rag/search-memos";
 import type { NoteSearchResult } from "@/lib/rag/search-notes";
 import { formatTime } from "@/utils";
 
@@ -12,6 +13,7 @@ type SemanticSearchResultsProps = {
   isPending: boolean;
   notes: NoteSearchResult[];
   glossary: GlossarySearchResult[];
+  memos: MemoSearchResult[];
   onResultClick?: () => void;
 };
 
@@ -24,7 +26,7 @@ function SimilarityBadge({ similarity }: { similarity: number }) {
 }
 
 export function SemanticSearchResults(props: SemanticSearchResultsProps) {
-  const { query, isPending, notes, glossary, onResultClick } = props;
+  const { query, isPending, notes, glossary, memos, onResultClick } = props;
 
   if (query.trim().length < 2) {
     return (
@@ -42,7 +44,8 @@ export function SemanticSearchResults(props: SemanticSearchResultsProps) {
     );
   }
 
-  const hasResults = notes.length > 0 || glossary.length > 0;
+  const hasResults =
+    notes.length > 0 || glossary.length > 0 || memos.length > 0;
   if (!hasResults) {
     return (
       <p className="text-muted-foreground py-8 text-center text-sm">
@@ -76,6 +79,33 @@ export function SemanticSearchResults(props: SemanticSearchResultsProps) {
                     <SimilarityBadge similarity={note.similarity} />
                   </div>
                   <p className="text-sm leading-relaxed">{note.content}</p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {memos.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-lg font-semibold">Mémos</h2>
+          <ul className="space-y-2">
+            {memos.map((memo) => (
+              <li key={memo.id}>
+                <Link
+                  href={`/notes/memo/${memo.id}`}
+                  onClick={onResultClick}
+                  className="bg-card hover:border-primary/50 block rounded-lg border-2 p-4 shadow-sm transition-all hover:shadow-md"
+                >
+                  <div className="mb-2 flex items-center justify-between gap-2">
+                    <span className="font-semibold">{memo.title}</span>
+                    <SimilarityBadge similarity={memo.similarity} />
+                  </div>
+                  {memo.content && (
+                    <p className="text-muted-foreground line-clamp-2 text-sm leading-relaxed whitespace-pre-wrap">
+                      {memo.content}
+                    </p>
+                  )}
                 </Link>
               </li>
             ))}

--- a/src/lib/rag/embed-content.ts
+++ b/src/lib/rag/embed-content.ts
@@ -44,6 +44,46 @@ export async function embedNoteIfNeeded(
   }
 }
 
+export async function embedMemoIfNeeded(
+  memoId: string,
+  title: string,
+  content: string,
+): Promise<void> {
+  try {
+    const composed = `${title}\n\n${content}`;
+    const hash = hashContent(composed);
+
+    const existing = await prisma.memo.findUnique({
+      where: { id: memoId },
+      select: { contentHash: true, embeddingModel: true },
+    });
+
+    if (
+      existing?.contentHash === hash &&
+      existing.embeddingModel === EMBEDDING_MODEL
+    ) {
+      return;
+    }
+
+    const embedding = await generateEmbedding(composed);
+    if (!embedding) {
+      return;
+    }
+
+    const vectorLiteral = toVectorLiteral(embedding);
+
+    await prisma.$executeRaw`
+      UPDATE "Memo"
+      SET "embedding" = ${Prisma.raw(`'${vectorLiteral}'::vector`)},
+          "contentHash" = ${hash},
+          "embeddingModel" = ${EMBEDDING_MODEL}
+      WHERE "id" = ${memoId}
+    `;
+  } catch (error) {
+    console.error("[rag] embedMemoIfNeeded failed", { memoId, error });
+  }
+}
+
 export async function embedGlossaryArticleIfNeeded(
   articleId: string,
   title: string,

--- a/src/lib/rag/search-memos.ts
+++ b/src/lib/rag/search-memos.ts
@@ -1,0 +1,54 @@
+import { generateEmbedding } from "@/lib/ai/openai";
+import { Prisma, prisma } from "@/lib/prisma";
+
+export type MemoSearchResult = {
+  id: string;
+  title: string;
+  content: string;
+  updatedAt: Date;
+  similarity: number;
+};
+
+type MemoSearchRow = {
+  id: string;
+  title: string;
+  content: string;
+  updatedAt: Date;
+  distance: number;
+};
+
+export async function searchMemosSemantic(
+  userId: string,
+  query: string,
+  limit = 10,
+): Promise<MemoSearchResult[]> {
+  const embedding = await generateEmbedding(query);
+  if (!embedding) {
+    return [];
+  }
+
+  const vectorLiteral = `[${embedding.join(",")}]`;
+  const vectorCast = Prisma.raw(`'${vectorLiteral}'::vector`);
+
+  const rows = await prisma.$queryRaw<MemoSearchRow[]>`
+    SELECT
+      "id",
+      "title",
+      "content",
+      "updatedAt",
+      "embedding" <=> ${vectorCast} AS "distance"
+    FROM "Memo"
+    WHERE "userId" = ${userId}
+      AND "embedding" IS NOT NULL
+    ORDER BY "embedding" <=> ${vectorCast}
+    LIMIT ${limit}
+  `;
+
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    content: row.content,
+    updatedAt: row.updatedAt,
+    similarity: 1 - row.distance,
+  }));
+}


### PR DESCRIPTION
## Summary

- New `Memo` model (title + content) with full CRUD: `/notes/memo` list, `/notes/memo/new`, `/notes/memo/[id]`
- pgvector embeddings on memos (`contentHash`, `embedding`, `embeddingModel`) + HNSW index, indexed on create/update via `embedMemoIfNeeded`
- Semantic search extended to memos: `searchMemos`, integrated into `/search`, Cmd+K dialog, and `backfill:embeddings`
- Eye icon on memo list opens preview dialog (mirrors strategy-matrix pattern)
- Dashboard CTA updated to surface memo creation
- DB: split memo migration into `add_memo` (table) + `add_memo_embedding` (RAG columns) to align with deployed state

## Type

feat

## Test plan

- [x] Create / edit / delete a memo from `/notes/memo`
- [x] Eye icon opens preview dialog with full content
- [x] Semantic search returns memos alongside notes and glossary
- [x] Cmd+K finds memos
- [x] `pnpm backfill:embeddings` re-indexes existing memos