### PR TITLE
refactor(strategy-matrix): Redesign pages with FGC sections and color-coded axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## 2026-06-04
 
+### Refactor: Redesign strategy matrix create/edit pages into numbered FGC sections (Modèle, Identité, Matchup, Axes, Matrice) with eyebrow/display headings, page glow and sticky action bar
+
+### Changed: Strategy matrix grid color-codes mine=accent columns / opponent=neutral rows with explicit orientation corner for readability
+
+### Added: Frame-data legend (avantage/désavantage/neutre) on the matrix builder and cell editor
+
+### Changed: Promote AI fill to an accent primary action and restyle templates, axis builders, matchup selector and cell editor to FGC tokens
+
 ### Refactor: Redesign /videos/[id] match view with FGC training-room layout (command-bar header, framed player with accent rail, polished note form and notes list)
 
 ### Added: Live video timecode HUD bar on the match page (replaces the unused StatusBar component)

--- a/app/(dashboard)/notes/strategy/[id]/page.tsx
+++ b/app/(dashboard)/notes/strategy/[id]/page.tsx
@@ -26,50 +26,67 @@ export default async function StrategyMatrixDetailPage({
   const matchupBadges = [
     matrix.game?.name,
     matrix.myCharacter?.name,
-    matrix.opponentCharacter?.name &&
-      `vs ${matrix.opponentCharacter.name}`,
+    matrix.opponentCharacter?.name && `vs ${matrix.opponentCharacter.name}`,
   ].filter(Boolean);
 
   return (
-    <div className="mx-auto max-w-7xl space-y-6 px-4 py-8">
-      <div className="flex items-start justify-between gap-4">
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold font-display">{matrix.title}</h1>
-          {matchupBadges.length > 0 && (
-            <div className="flex flex-wrap gap-2">
-              {matchupBadges.map((label) => (
-                <span
-                  key={label}
-                  className="bg-muted text-muted-foreground rounded-full px-2.5 py-0.5 text-xs"
-                >
-                  {label}
-                </span>
-              ))}
-            </div>
-          )}
-          {matrix.description && (
-            <p className="text-muted-foreground mt-1">{matrix.description}</p>
-          )}
-        </div>
-        <StrategyMatrixHelpDialog />
-      </div>
-
-      <StrategyMatrixForm
-        mode="edit"
-        matrixId={matrix.id}
-        games={games}
-        charactersByGame={charactersByGame}
-        initialData={{
-          title: matrix.title,
-          description: matrix.description ?? undefined,
-          gameId: matrix.gameId ?? undefined,
-          myCharacterId: matrix.myCharacterId ?? undefined,
-          opponentCharacterId: matrix.opponentCharacterId ?? undefined,
-          myAxis: matrix.myAxis,
-          opponentAxis: matrix.opponentAxis,
-          cells: matrix.cells,
+    <div className="relative">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[320px]"
+        style={{
+          background:
+            "radial-gradient(ellipse 55% 60% at 50% 0%, var(--fgc-accent-soft) 0%, transparent 70%)",
         }}
       />
+
+      <div className="mx-auto max-w-7xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 space-y-2">
+            <div className="text-muted-foreground mb-1 font-mono text-[10px] tracking-[0.2em] uppercase">
+              <span className="text-primary">Matrice</span> · Édition
+            </div>
+            <h1 className="font-display text-2xl uppercase md:text-3xl">
+              {matrix.title}
+            </h1>
+            {matchupBadges.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {matchupBadges.map((label) => (
+                  <span
+                    key={label}
+                    className="border-border bg-secondary text-muted-foreground rounded-full border px-2.5 py-0.5 font-mono text-xs"
+                  >
+                    {label}
+                  </span>
+                ))}
+              </div>
+            )}
+            {matrix.description && (
+              <p className="text-muted-foreground max-w-2xl text-sm">
+                {matrix.description}
+              </p>
+            )}
+          </div>
+          <StrategyMatrixHelpDialog />
+        </div>
+
+        <StrategyMatrixForm
+          mode="edit"
+          matrixId={matrix.id}
+          games={games}
+          charactersByGame={charactersByGame}
+          initialData={{
+            title: matrix.title,
+            description: matrix.description ?? undefined,
+            gameId: matrix.gameId ?? undefined,
+            myCharacterId: matrix.myCharacterId ?? undefined,
+            opponentCharacterId: matrix.opponentCharacterId ?? undefined,
+            myAxis: matrix.myAxis,
+            opponentAxis: matrix.opponentAxis,
+            cells: matrix.cells,
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/app/(dashboard)/notes/strategy/new/page.tsx
+++ b/app/(dashboard)/notes/strategy/new/page.tsx
@@ -14,23 +14,39 @@ export default async function NewStrategyMatrixPage() {
   ]);
 
   return (
-    <div className="mx-auto max-w-7xl space-y-6 px-4 py-8">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-bold font-display">Nouvelle matrice de stratégie</h1>
-          <p className="text-muted-foreground mt-1">
-            Définissez vos axes (mes ressources × ressources adverses) et
-            remplissez chaque cellule avec votre stratégie.
-          </p>
-        </div>
-        <StrategyMatrixHelpDialog />
-      </div>
-
-      <StrategyMatrixForm
-        mode="create"
-        games={games}
-        charactersByGame={charactersByGame}
+    <div className="relative">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[320px]"
+        style={{
+          background:
+            "radial-gradient(ellipse 55% 60% at 50% 0%, var(--fgc-accent-soft) 0%, transparent 70%)",
+        }}
       />
+
+      <div className="mx-auto max-w-7xl space-y-8 px-4 py-8 sm:px-6 lg:px-8">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-muted-foreground mb-2 font-mono text-[10px] tracking-[0.2em] uppercase">
+              <span className="text-primary">Matrice</span> · Nouvelle
+            </div>
+            <h1 className="font-display text-2xl uppercase md:text-3xl">
+              Prépare un matchup
+            </h1>
+            <p className="text-muted-foreground mt-2 max-w-2xl text-sm">
+              Croise tes ressources et celles de l&apos;adversaire, puis remplis
+              chaque cellule avec ta stratégie optimale.
+            </p>
+          </div>
+          <StrategyMatrixHelpDialog />
+        </div>
+
+        <StrategyMatrixForm
+          mode="create"
+          games={games}
+          charactersByGame={charactersByGame}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/features/strategy-matrix/frame-legend.tsx
+++ b/src/components/features/strategy-matrix/frame-legend.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/lib/utils";
+
+const ITEMS = [
+  { sample: "(+N)", label: "Avantage", cls: "text-frame-positive" },
+  { sample: "(-N)", label: "Désavantage", cls: "text-frame-negative" },
+  { sample: "(0)", label: "Neutre", cls: "text-frame-neutral" },
+] as const;
+
+type FrameLegendProps = {
+  className?: string;
+};
+
+export function FrameLegend(props: FrameLegendProps) {
+  const { className } = props;
+
+  return (
+    <div
+      className={cn("flex flex-wrap items-center gap-x-4 gap-y-1", className)}
+    >
+      <span className="text-muted-foreground font-mono text-[10px] tracking-[0.2em] uppercase">
+        Frame data
+      </span>
+      {ITEMS.map((item) => (
+        <span key={item.label} className="flex items-center gap-1.5 text-xs">
+          <code className={cn("font-mono font-semibold", item.cls)}>
+            {item.sample}
+          </code>
+          <span className="text-muted-foreground">{item.label}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/features/strategy-matrix/strategy-matrix-ai-fill-button.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-ai-fill-button.tsx
@@ -84,7 +84,6 @@ export function StrategyMatrixAiFillButton({
     <>
       <Button
         type="button"
-        variant="outline"
         size="sm"
         onClick={handleClick}
         disabled={isPending || !hasTitle}
@@ -94,7 +93,7 @@ export function StrategyMatrixAiFillButton({
         ) : (
           <Sparkles className="mr-2 h-4 w-4" />
         )}
-        {isPending ? "Génération…" : "Remplir avec IA"}
+        {isPending ? "Génération…" : "Remplir avec l'IA"}
       </Button>
 
       <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>

--- a/src/components/features/strategy-matrix/strategy-matrix-axis-builder.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-axis-builder.tsx
@@ -10,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
 import { Plus, Trash2 } from "lucide-react";
 import type { Axis, Level, ResourceType } from "./strategy-matrix-schema";
 import { RESOURCE_TYPES } from "./strategy-matrix-schema";
@@ -23,13 +24,19 @@ type Props = {
   axis: Axis;
   onChange: (axis: Axis) => void;
   heading: string;
+  tone?: "mine" | "opponent";
 };
 
 function generateLevelId(): string {
   return `lvl-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-export function StrategyMatrixAxisBuilder({ axis, onChange, heading }: Props) {
+export function StrategyMatrixAxisBuilder({
+  axis,
+  onChange,
+  heading,
+  tone = "mine",
+}: Props) {
   const updateLabel = (label: string) => onChange({ ...axis, label });
 
   const updateResource = (resource: ResourceType) =>
@@ -61,8 +68,16 @@ export function StrategyMatrixAxisBuilder({ axis, onChange, heading }: Props) {
   };
 
   return (
-    <div className="space-y-3 rounded-lg border p-4">
-      <h3 className="text-sm font-semibold">{heading}</h3>
+    <div className="border-border bg-card space-y-3 rounded-xl border p-4">
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "size-2 rounded-full",
+            tone === "mine" ? "bg-primary" : "bg-muted-foreground",
+          )}
+        />
+        <h3 className="font-display text-sm uppercase">{heading}</h3>
+      </div>
 
       <div className="space-y-2">
         <Label htmlFor={`axis-label-${heading}`}>Libellé de l&apos;axe</Label>

--- a/src/components/features/strategy-matrix/strategy-matrix-cell-editor.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-cell-editor.tsx
@@ -34,6 +34,7 @@ import { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { frameDataComponents } from "./frame-data-renderer";
+import { FrameLegend } from "./frame-legend";
 import {
   FGC_ACTIONS,
   FGC_BUTTONS,
@@ -148,18 +149,23 @@ export function StrategyMatrixCellEditor({
           }}
         >
           <DialogHeader>
-            <DialogTitle>
-              {myLevelLabel} × {opponentLevelLabel}
+            <div className="text-muted-foreground font-mono text-[10px] tracking-[0.2em] uppercase">
+              Cellule de stratégie
+            </div>
+            <DialogTitle className="font-display flex items-center gap-2 uppercase">
+              <span className="text-primary">{myLevelLabel}</span>
+              <span className="text-muted-foreground">×</span>
+              <span>{opponentLevelLabel}</span>
             </DialogTitle>
             <DialogDescription>
-              Décrivez votre stratégie pour cette combinaison d&apos;états.
-              Markdown supporté.
+              Décris ta stratégie pour cette combinaison d&apos;états. Markdown
+              supporté.
             </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-2">
             <div className="flex items-center justify-between">
-              <span className="text-muted-foreground text-xs">
+              <span className="text-muted-foreground font-mono text-xs tabular-nums">
                 {content.length} / {MAX_CELL_LENGTH}
               </span>
               <Button
@@ -268,6 +274,8 @@ export function StrategyMatrixCellEditor({
                 className="min-h-[200px]"
               />
             )}
+
+            <FrameLegend className="pt-1" />
           </div>
 
           <DialogFooter>

--- a/src/components/features/strategy-matrix/strategy-matrix-filters.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-filters.tsx
@@ -36,10 +36,7 @@ export function StrategyMatrixFilters({
     ? (charactersByGame[selectedGameId] ?? [])
     : [];
 
-  const updateParams = (next: {
-    gameId?: string;
-    characterId?: string;
-  }) => {
+  const updateParams = (next: { gameId?: string; characterId?: string }) => {
     const params = new URLSearchParams(searchParams.toString());
     if (next.gameId) params.set("gameId", next.gameId);
     else params.delete("gameId");
@@ -109,11 +106,7 @@ export function StrategyMatrixFilters({
       </div>
 
       {hasFilter && (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => updateParams({})}
-        >
+        <Button variant="ghost" size="sm" onClick={() => updateParams({})}>
           Réinitialiser
         </Button>
       )}

--- a/src/components/features/strategy-matrix/strategy-matrix-form.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-form.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button";
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -15,7 +14,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useAction } from "next-safe-action/hooks";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type {
@@ -26,6 +25,7 @@ import {
   createStrategyMatrixAction,
   updateStrategyMatrixAction,
 } from "./strategy-matrix-action";
+import { FrameLegend } from "./frame-legend";
 import { StrategyMatrixAiFillButton } from "./strategy-matrix-ai-fill-button";
 import { StrategyMatrixAxisBuilder } from "./strategy-matrix-axis-builder";
 import { StrategyMatrixCellEditor } from "./strategy-matrix-cell-editor";
@@ -72,6 +72,38 @@ type EditingCell = {
   myLevelId: string;
   opponentLevelId: string;
 } | null;
+
+type MatrixSectionProps = {
+  index: string;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  children: ReactNode;
+};
+
+function MatrixSection(props: MatrixSectionProps) {
+  const { index, title, description, action, children } = props;
+
+  return (
+    <section className="border-border bg-card rounded-xl border p-5">
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-baseline gap-3">
+            <span className="text-primary font-mono text-xs">{index}</span>
+            <h2 className="font-display text-lg uppercase">{title}</h2>
+          </div>
+          {description && (
+            <p className="text-muted-foreground mt-1.5 text-sm">
+              {description}
+            </p>
+          )}
+        </div>
+        {action}
+      </div>
+      {children}
+    </section>
+  );
+}
 
 export function StrategyMatrixForm(props: Props) {
   const router = useRouter();
@@ -178,7 +210,11 @@ export function StrategyMatrixForm(props: Props) {
   };
 
   const handleAiCellsGenerated = (
-    generated: { myLevelId: string; opponentLevelId: string; content: string }[],
+    generated: {
+      myLevelId: string;
+      opponentLevelId: string;
+      content: string;
+    }[],
   ) => {
     const lookup = buildCellLookup(form.getValues("cells"));
     for (const cell of generated) {
@@ -220,77 +256,114 @@ export function StrategyMatrixForm(props: Props) {
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
         {props.mode === "create" && (
-          <div className="space-y-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => setShowTemplatePicker((v) => !v)}
-            >
-              {showTemplatePicker ? "Masquer les modèles" : "Choisir un modèle"}
-            </Button>
-            {showTemplatePicker && (
-              <StrategyMatrixTemplateSelector onSelect={handleSelectTemplate} />
-            )}
-          </div>
+          <MatrixSection
+            index="00"
+            title="Pars d'un modèle"
+            description="Un point de départ rapide pour ne pas démarrer d'une page blanche. Tu personnalises tout ensuite."
+          >
+            <div className="space-y-4">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setShowTemplatePicker((v) => !v)}
+              >
+                {showTemplatePicker
+                  ? "Masquer les modèles"
+                  : "Voir les modèles"}
+              </Button>
+              {showTemplatePicker && (
+                <StrategyMatrixTemplateSelector
+                  onSelect={handleSelectTemplate}
+                />
+              )}
+            </div>
+          </MatrixSection>
         )}
 
-        <FormField
-          control={form.control}
-          name="title"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Titre</FormLabel>
-              <FormControl>
-                <Input placeholder="Ex: Stratégie défensive Ken" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <MatrixSection
+          index="01"
+          title="Identité"
+          description="Nomme ta matrice pour la retrouver d'un coup d'œil avant un set."
+        >
+          <div className="space-y-4">
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Titre</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Ex: Ken vs Juri — défense en burnout"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-        <FormField
-          control={form.control}
-          name="description"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Description (optionnelle)</FormLabel>
-              <FormControl>
-                <Textarea
-                  placeholder="Contexte ou conditions générales d'utilisation de cette matrice"
-                  value={field.value ?? ""}
-                  onChange={field.onChange}
-                  className="min-h-[60px]"
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description (optionnelle)</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Contexte ou conditions d'utilisation de cette matrice"
+                      value={field.value ?? ""}
+                      onChange={field.onChange}
+                      className="min-h-[60px]"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </MatrixSection>
 
-        <StrategyMatrixMatchupSelector
-          games={props.games}
-          charactersByGame={props.charactersByGame}
-          value={{ gameId, myCharacterId, opponentCharacterId }}
-          onChange={handleMatchupChange}
-        />
-
-        <div className="grid gap-4 md:grid-cols-2">
-          <StrategyMatrixAxisBuilder
-            heading="Mon état (colonnes)"
-            axis={myAxis}
-            onChange={(next) => handleAxisChange("myAxis", next)}
+        <MatrixSection
+          index="02"
+          title="Matchup"
+          description="Associe un jeu et des persos pour retrouver la matrice par matchup (optionnel)."
+        >
+          <StrategyMatrixMatchupSelector
+            games={props.games}
+            charactersByGame={props.charactersByGame}
+            value={{ gameId, myCharacterId, opponentCharacterId }}
+            onChange={handleMatchupChange}
           />
-          <StrategyMatrixAxisBuilder
-            heading="État adversaire (lignes)"
-            axis={opponentAxis}
-            onChange={(next) => handleAxisChange("opponentAxis", next)}
-          />
-        </div>
+        </MatrixSection>
 
-        <div className="space-y-2">
-          <div className="flex items-center justify-between gap-2">
-            <FormLabel>Matrice</FormLabel>
+        <MatrixSection
+          index="03"
+          title="Axes"
+          description="Tes ressources en colonnes, celles de l'adversaire en lignes. 2 à 5 niveaux par axe."
+        >
+          <div className="grid gap-4 md:grid-cols-2">
+            <StrategyMatrixAxisBuilder
+              tone="mine"
+              heading="Mon état (colonnes →)"
+              axis={myAxis}
+              onChange={(next) => handleAxisChange("myAxis", next)}
+            />
+            <StrategyMatrixAxisBuilder
+              tone="opponent"
+              heading="État adverse (lignes ↓)"
+              axis={opponentAxis}
+              onChange={(next) => handleAxisChange("opponentAxis", next)}
+            />
+          </div>
+        </MatrixSection>
+
+        <MatrixSection
+          index="04"
+          title="Matrice"
+          description="Clique une cellule pour décrire la stratégie optimale — ou laisse l'IA remplir toute la grille."
+          action={
             <StrategyMatrixAiFillButton
               title={form.watch("title")}
               description={form.watch("description")}
@@ -302,21 +375,22 @@ export function StrategyMatrixForm(props: Props) {
               cells={cells}
               onCellsGenerated={handleAiCellsGenerated}
             />
+          }
+        >
+          <div className="space-y-3">
+            <FrameLegend />
+            <StrategyMatrixGrid
+              myAxis={myAxis}
+              opponentAxis={opponentAxis}
+              cells={cells}
+              onCellClick={(myLevelId, opponentLevelId) =>
+                setEditingCell({ myLevelId, opponentLevelId })
+              }
+            />
           </div>
-          <FormDescription>
-            Cliquez sur une cellule pour éditer son contenu en markdown.
-          </FormDescription>
-          <StrategyMatrixGrid
-            myAxis={myAxis}
-            opponentAxis={opponentAxis}
-            cells={cells}
-            onCellClick={(myLevelId, opponentLevelId) =>
-              setEditingCell({ myLevelId, opponentLevelId })
-            }
-          />
-        </div>
+        </MatrixSection>
 
-        <div className="flex justify-end gap-2">
+        <div className="border-border bg-background/80 sticky bottom-0 z-10 flex items-center justify-end gap-2 rounded-xl border px-4 py-3 backdrop-blur">
           <Button
             type="button"
             variant="outline"

--- a/src/components/features/strategy-matrix/strategy-matrix-grid.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-grid.tsx
@@ -33,19 +33,20 @@ export function StrategyMatrixGrid({
   return (
     <div className="overflow-x-auto">
       <div
-        className="bg-border grid min-w-fit gap-px rounded-lg border"
+        className="bg-border grid min-w-fit gap-px overflow-hidden rounded-xl border"
         style={{
           gridTemplateColumns: `minmax(140px, 200px) repeat(${columnCount}, minmax(160px, 1fr))`,
         }}
       >
-        <div className="bg-muted text-muted-foreground flex items-center justify-center p-3 text-xs font-semibold">
-          {opponentAxis.label} ↓ / {myAxis.label} →
+        <div className="bg-secondary flex flex-col justify-center gap-0.5 p-3 font-mono text-[10px] uppercase">
+          <span className="text-muted-foreground">↓ {opponentAxis.label}</span>
+          <span className="text-primary">{myAxis.label} →</span>
         </div>
 
         {myAxis.levels.map((my) => (
           <div
             key={my.id}
-            className="bg-muted text-foreground flex items-center justify-center p-3 text-center text-sm font-semibold"
+            className="bg-accent text-primary flex items-center justify-center p-3 text-center font-mono text-xs font-semibold uppercase"
           >
             {my.label}
           </div>
@@ -53,7 +54,7 @@ export function StrategyMatrixGrid({
 
         {opponentAxis.levels.map((opp) => (
           <div key={opp.id} className="contents">
-            <div className="bg-muted text-foreground flex items-center justify-center p-3 text-center text-sm font-semibold">
+            <div className="bg-secondary text-foreground flex items-center justify-center p-3 text-center font-mono text-xs font-semibold">
               {opp.label}
             </div>
             {myAxis.levels.map((my) => {
@@ -67,14 +68,17 @@ export function StrategyMatrixGrid({
                   onClick={() => !readOnly && onCellClick?.(my.id, opp.id)}
                   disabled={readOnly}
                   className={cn(
-                    "bg-card text-foreground min-h-[100px] p-3 text-left text-sm transition-colors",
-                    !readOnly && "hover:bg-accent cursor-pointer",
+                    "bg-card text-foreground min-h-[110px] p-3 text-left text-sm leading-relaxed transition-colors",
+                    !readOnly &&
+                      "hover:border-primary/40 hover:bg-accent cursor-pointer border border-transparent",
                     readOnly && "cursor-default",
-                    isEmpty && "text-muted-foreground italic",
+                    isEmpty && "text-muted-foreground/70 italic",
                   )}
                 >
                   {isEmpty
-                    ? "Vide — cliquez pour éditer"
+                    ? readOnly
+                      ? "—"
+                      : "Vide · clique pour éditer"
                     : previewContent(content)}
                 </button>
               );

--- a/src/components/features/strategy-matrix/strategy-matrix-help-dialog.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-help-dialog.tsx
@@ -26,7 +26,9 @@ export function StrategyMatrixHelpDialog() {
       </DialogTrigger>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
-          <DialogTitle>Comment utiliser une matrice de stratégie ?</DialogTitle>
+          <DialogTitle className="font-display uppercase">
+            Comment utiliser une matrice ?
+          </DialogTitle>
           <DialogDescription>
             Une matrice croise <strong>votre état</strong> (colonnes) et{" "}
             <strong>l&apos;état adverse</strong> (lignes). Chaque cellule
@@ -37,7 +39,7 @@ export function StrategyMatrixHelpDialog() {
 
         <div className="space-y-6 text-sm">
           <section className="space-y-2">
-            <h3 className="text-base font-semibold">Étapes</h3>
+            <h3 className="font-display text-sm uppercase">Étapes</h3>
             <ol className="text-muted-foreground list-decimal space-y-1.5 pl-5">
               <li>
                 <strong className="text-foreground">Choisir un modèle</strong>{" "}
@@ -66,7 +68,7 @@ export function StrategyMatrixHelpDialog() {
           </section>
 
           <section className="space-y-2">
-            <h3 className="text-base font-semibold">Exemple concret</h3>
+            <h3 className="font-display text-sm uppercase">Exemple concret</h3>
             <p className="text-muted-foreground">
               Matrice : <em>Mon Drive Gauge</em> (colonnes) ×{" "}
               <em>Position adversaire</em> (lignes).
@@ -76,12 +78,8 @@ export function StrategyMatrixHelpDialog() {
                 <thead className="bg-muted">
                   <tr>
                     <th className="p-2 text-left font-semibold"></th>
-                    <th className="p-2 text-left font-semibold">
-                      Drive plein
-                    </th>
-                    <th className="p-2 text-left font-semibold">
-                      Drive moyen
-                    </th>
+                    <th className="p-2 text-left font-semibold">Drive plein</th>
+                    <th className="p-2 text-left font-semibold">Drive moyen</th>
                     <th className="p-2 text-left font-semibold">Burnout</th>
                   </tr>
                 </thead>
@@ -118,7 +116,7 @@ export function StrategyMatrixHelpDialog() {
           </section>
 
           <section className="space-y-2">
-            <h3 className="text-base font-semibold">Bonnes pratiques</h3>
+            <h3 className="font-display text-sm uppercase">Bonnes pratiques</h3>
             <ul className="text-muted-foreground list-disc space-y-1 pl-5">
               <li>
                 Une matrice = <strong>une situation</strong> précise (un

--- a/src/components/features/strategy-matrix/strategy-matrix-list.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-list.tsx
@@ -71,85 +71,89 @@ export function StrategyMatrixList({ matrices }: Props) {
         ].filter(Boolean) as string[];
 
         return (
-        <Card key={matrix.id} className="flex flex-col gap-3 p-4">
-          <div className="space-y-1">
-            <h3 className="line-clamp-1 font-semibold">{matrix.title}</h3>
-            {matchupBadges.length > 0 && (
-              <div className="flex flex-wrap gap-1">
-                {matchupBadges.map((label) => (
-                  <span
-                    key={label}
-                    className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-[10px]"
-                  >
-                    {label}
-                  </span>
-                ))}
-              </div>
-            )}
-            {matrix.description && (
-              <p className="text-muted-foreground line-clamp-2 text-sm">
-                {matrix.description}
-              </p>
-            )}
-          </div>
-          <div className="text-muted-foreground text-xs">
-            {safeAxisLabel(matrix.myAxis)} ×{" "}
-            {safeAxisLabel(matrix.opponentAxis)}
-          </div>
-          <div className="mt-auto flex justify-end gap-2">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button asChild size="icon" variant="outline">
-                  <Link
-                    href={`/notes/strategy/${matrix.id}`}
-                    aria-label="Ouvrir"
-                  >
-                    <FolderOpen className="h-4 w-4" />
-                  </Link>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Ouvrir</TooltipContent>
-            </Tooltip>
-            <StrategyMatrixVisualizeDialog
-              title={matrix.title}
-              myAxis={matrix.myAxis}
-              opponentAxis={matrix.opponentAxis}
-              cells={matrix.cells}
-            />
-            <AlertDialog>
+          <Card key={matrix.id} className="flex flex-col gap-3 p-4">
+            <div className="space-y-1">
+              <h3 className="line-clamp-1 font-semibold">{matrix.title}</h3>
+              {matchupBadges.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {matchupBadges.map((label) => (
+                    <span
+                      key={label}
+                      className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-[10px]"
+                    >
+                      {label}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {matrix.description && (
+                <p className="text-muted-foreground line-clamp-2 text-sm">
+                  {matrix.description}
+                </p>
+              )}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {safeAxisLabel(matrix.myAxis)} ×{" "}
+              {safeAxisLabel(matrix.opponentAxis)}
+            </div>
+            <div className="mt-auto flex justify-end gap-2">
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      disabled={isPending}
-                      aria-label="Supprimer"
+                  <Button asChild size="icon" variant="outline">
+                    <Link
+                      href={`/notes/strategy/${matrix.id}`}
+                      aria-label="Ouvrir"
                     >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </AlertDialogTrigger>
+                      <FolderOpen className="h-4 w-4" />
+                    </Link>
+                  </Button>
                 </TooltipTrigger>
-                <TooltipContent>Supprimer</TooltipContent>
+                <TooltipContent>Ouvrir</TooltipContent>
               </Tooltip>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Supprimer cette matrice ?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    Cette action est irréversible. La matrice « {matrix.title} »
-                    sera définitivement supprimée.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Annuler</AlertDialogCancel>
-                  <AlertDialogAction onClick={() => execute({ id: matrix.id })}>
-                    Supprimer
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </div>
-        </Card>
+              <StrategyMatrixVisualizeDialog
+                title={matrix.title}
+                myAxis={matrix.myAxis}
+                opponentAxis={matrix.opponentAxis}
+                cells={matrix.cells}
+              />
+              <AlertDialog>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        disabled={isPending}
+                        aria-label="Supprimer"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </AlertDialogTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>Supprimer</TooltipContent>
+                </Tooltip>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>
+                      Supprimer cette matrice ?
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Cette action est irréversible. La matrice « {matrix.title}{" "}
+                      » sera définitivement supprimée.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Annuler</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => execute({ id: matrix.id })}
+                    >
+                      Supprimer
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
+          </Card>
         );
       })}
     </div>

--- a/src/components/features/strategy-matrix/strategy-matrix-matchup-selector.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-matchup-selector.tsx
@@ -33,9 +33,7 @@ export function StrategyMatrixMatchupSelector({
   value,
   onChange,
 }: Props) {
-  const characters = value.gameId
-    ? (charactersByGame[value.gameId] ?? [])
-    : [];
+  const characters = value.gameId ? (charactersByGame[value.gameId] ?? []) : [];
 
   const handleGameChange = (raw: string) => {
     const gameId = raw === NONE_VALUE ? undefined : raw;
@@ -57,79 +55,73 @@ export function StrategyMatrixMatchupSelector({
   };
 
   return (
-    <div className="space-y-3 rounded-md border p-4">
+    <div className="grid gap-3 md:grid-cols-3">
       <div className="space-y-1">
-        <h3 className="text-sm font-semibold">Contexte matchup (optionnel)</h3>
-        <p className="text-muted-foreground text-xs">
-          Associez cette matrice à un jeu et à des personnages pour pouvoir la
-          retrouver par matchup.
-        </p>
+        <label className="text-muted-foreground font-mono text-[10px] tracking-[0.2em] uppercase">
+          Jeu
+        </label>
+        <Select
+          value={value.gameId ?? NONE_VALUE}
+          onValueChange={handleGameChange}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Aucun" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={NONE_VALUE}>Aucun</SelectItem>
+            {games.map((g) => (
+              <SelectItem key={g.id} value={g.id}>
+                {g.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-3">
-        <div className="space-y-1">
-          <label className="text-xs font-medium">Jeu</label>
-          <Select
-            value={value.gameId ?? NONE_VALUE}
-            onValueChange={handleGameChange}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Aucun" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={NONE_VALUE}>Aucun</SelectItem>
-              {games.map((g) => (
-                <SelectItem key={g.id} value={g.id}>
-                  {g.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+      <div className="space-y-1">
+        <label className="text-muted-foreground font-mono text-[10px] tracking-[0.2em] uppercase">
+          Mon personnage
+        </label>
+        <Select
+          value={value.myCharacterId ?? NONE_VALUE}
+          onValueChange={(v) => handleCharacterChange("myCharacterId", v)}
+          disabled={!value.gameId || characters.length === 0}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Aucun" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={NONE_VALUE}>Aucun</SelectItem>
+            {characters.map((c) => (
+              <SelectItem key={c.id} value={c.id}>
+                {c.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
 
-        <div className="space-y-1">
-          <label className="text-xs font-medium">Mon personnage</label>
-          <Select
-            value={value.myCharacterId ?? NONE_VALUE}
-            onValueChange={(v) => handleCharacterChange("myCharacterId", v)}
-            disabled={!value.gameId || characters.length === 0}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Aucun" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={NONE_VALUE}>Aucun</SelectItem>
-              {characters.map((c) => (
-                <SelectItem key={c.id} value={c.id}>
-                  {c.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="space-y-1">
-          <label className="text-xs font-medium">Personnage adverse</label>
-          <Select
-            value={value.opponentCharacterId ?? NONE_VALUE}
-            onValueChange={(v) =>
-              handleCharacterChange("opponentCharacterId", v)
-            }
-            disabled={!value.gameId || characters.length === 0}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Aucun" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={NONE_VALUE}>Aucun</SelectItem>
-              {characters.map((c) => (
-                <SelectItem key={c.id} value={c.id}>
-                  {c.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+      <div className="space-y-1">
+        <label className="text-muted-foreground font-mono text-[10px] tracking-[0.2em] uppercase">
+          Personnage adverse
+        </label>
+        <Select
+          value={value.opponentCharacterId ?? NONE_VALUE}
+          onValueChange={(v) => handleCharacterChange("opponentCharacterId", v)}
+          disabled={!value.gameId || characters.length === 0}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Aucun" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={NONE_VALUE}>Aucun</SelectItem>
+            {characters.map((c) => (
+              <SelectItem key={c.id} value={c.id}>
+                {c.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
     </div>
   );

--- a/src/components/features/strategy-matrix/strategy-matrix-template-selector.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-template-selector.tsx
@@ -15,14 +15,17 @@ export function StrategyMatrixTemplateSelector({ onSelect }: Props) {
   return (
     <div className="grid gap-4 md:grid-cols-3">
       {STRATEGY_MATRIX_TEMPLATES.map((template) => (
-        <Card key={template.id} className="flex flex-col gap-3 p-4">
+        <Card
+          key={template.id}
+          className="hover:border-primary/40 flex flex-col gap-3 p-4 transition-colors"
+        >
           <div>
-            <h3 className="font-semibold">{template.name}</h3>
-            <p className="text-muted-foreground mt-1 text-sm">
+            <h3 className="font-display text-sm uppercase">{template.name}</h3>
+            <p className="text-muted-foreground mt-1.5 text-sm">
               {template.description}
             </p>
           </div>
-          <div className="text-muted-foreground text-xs">
+          <div className="text-muted-foreground font-mono text-xs">
             {template.myAxis.levels.length} ×{" "}
             {template.opponentAxis.levels.length} cellules
           </div>


### PR DESCRIPTION
## Summary

• Restructured matrix create/edit form into numbered FGC sections (Modèle, Identité, Matchup, Axes, Matrice) with eyebrow/display headings
• Color-coded grid axes for clarity: mine=accent red columns, opponent=neutral gray rows, with explicit orientation corner
• Added frame-data legend (avantage/désavantage/neutre) to builder and cell editor
• Promoted AI fill to accent primary action in section header
• Styled all sub-components (axis builders, matchup selector, templates, cell editor, help) to FGC tokens
• Sticky bottom action bar keeps Save/Cancel visible while scrolling
• Updated page headers (new/[id]) with eyebrow, page-level glow, and mono badge matchups
• Fixed form layout: replaced card wrapper with section cards, improved spacing and visual hierarchy

## Type

refactor