### PR TITLE
fix: double search dialog fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## 2026-06-04
 
+### Fixed: Search command dialog opened twice (duplicate mounted instances) — single store-driven dialog with shared trigger buttons
+
+### Changed: Show landing page anchor links in the header only on the landing page
+
 ### Changed: Render strategy matrix cells with the markdown preview (frame-data colors, formatting) instead of plain truncated text
 
 ### Refactor: Redesign strategy matrix create/edit pages into numbered FGC sections (Modèle, Identité, Matchup, Axes, Matrice) with eyebrow/display headings, page glow and sticky action bar

--- a/src/components/features/dashboard/cmdk-trigger-button.tsx
+++ b/src/components/features/dashboard/cmdk-trigger-button.tsx
@@ -3,25 +3,21 @@
 import { Command } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { useSearchDialogStore } from "@/stores/search-dialog";
 
 type CmdkTriggerButtonProps = {
   className?: string;
   label?: string;
 };
 
-function openSearch() {
-  window.dispatchEvent(
-    new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }),
-  );
-}
-
 export function CmdkTriggerButton(props: CmdkTriggerButtonProps) {
   const { className, label = "Chercher dans ton labo" } = props;
+  const setOpen = useSearchDialogStore((state) => state.setOpen);
 
   return (
     <button
       type="button"
-      onClick={openSearch}
+      onClick={() => setOpen(true)}
       className={cn(
         "border-border bg-card text-muted-foreground hover:text-foreground hover:border-muted-foreground/40 inline-flex h-12 items-center gap-2 rounded-md border px-4 text-sm transition-colors",
         className,

--- a/src/components/features/landing/authenticated-nav.tsx
+++ b/src/components/features/landing/authenticated-nav.tsx
@@ -7,6 +7,7 @@ import { ChevronDown, Menu } from "lucide-react";
 import { UserProfileDropdown } from "@/components/features/auth/user-profile-dropdown";
 import { NavLink } from "@/components/features/landing/nav-link";
 import { SearchCommandDialog } from "@/components/features/search/search-command-dialog";
+import { SearchTriggerButton } from "@/components/features/search/search-trigger-button";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -66,12 +67,12 @@ export function AuthenticatedNav({ user }: AuthenticatedNavProps) {
             </DropdownMenuContent>
           </DropdownMenu>
         )}
-        <SearchCommandDialog />
+        <SearchTriggerButton />
         <UserProfileDropdown user={user} />
       </div>
 
       <div className="flex items-center gap-2 lg:hidden">
-        <SearchCommandDialog />
+        <SearchTriggerButton />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" size="icon" aria-label="Menu">
@@ -110,6 +111,8 @@ export function AuthenticatedNav({ user }: AuthenticatedNavProps) {
         </DropdownMenu>
         <UserProfileDropdown user={user} />
       </div>
+
+      <SearchCommandDialog />
     </>
   );
 }

--- a/src/components/features/landing/header.tsx
+++ b/src/components/features/landing/header.tsx
@@ -7,6 +7,7 @@ import { useUserRole } from "@/hooks/use-user-role";
 import { useSession } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
 const NAV_LINKS = [
@@ -19,6 +20,8 @@ const NAV_LINKS = [
 export function Header() {
   const { data: session, isPending } = useSession();
   const { role } = useUserRole();
+  const pathname = usePathname();
+  const isLandingPage = pathname === "/";
   const [scrolled, setScrolled] = useState(false);
 
   useEffect(() => {
@@ -51,17 +54,19 @@ export function Header() {
             </span>
           </Link>
 
-          <nav className="hidden items-center gap-1 md:flex">
-            {NAV_LINKS.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                className="text-fgc-muted hover:text-fgc-text rounded-md px-3 py-1.5 text-sm transition-colors"
-              >
-                {link.label}
-              </Link>
-            ))}
-          </nav>
+          {isLandingPage ? (
+            <nav className="hidden items-center gap-1 md:flex">
+              {NAV_LINKS.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="text-fgc-muted hover:text-fgc-text rounded-md px-3 py-1.5 text-sm transition-colors"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </nav>
+          ) : null}
 
           <div className="flex items-center gap-2">
             {isPending ? (

--- a/src/components/features/search/search-command-dialog.test.tsx
+++ b/src/components/features/search/search-command-dialog.test.tsx
@@ -14,23 +14,24 @@ vi.mock("./semantic-search-action", () => ({
   semanticSearchAction: vi.fn(),
 }));
 
+import { useSearchDialogStore } from "@/stores/search-dialog";
 import { SearchCommandDialog } from "./search-command-dialog";
+import { SearchTriggerButton } from "./search-trigger-button";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  useSearchDialogStore.setState({ open: false });
 });
 
 describe("SearchCommandDialog", () => {
-  it("renders trigger button", () => {
-    render(<SearchCommandDialog />);
-    expect(
-      screen.getByRole("button", { name: /ouvrir la recherche/i }),
-    ).toBeInTheDocument();
-  });
-
-  it("opens dialog on trigger click", async () => {
+  it("opens dialog on trigger button click", async () => {
     const user = userEvent.setup();
-    render(<SearchCommandDialog />);
+    render(
+      <>
+        <SearchTriggerButton />
+        <SearchCommandDialog />
+      </>,
+    );
     await user.click(
       screen.getByRole("button", { name: /ouvrir la recherche/i }),
     );

--- a/src/components/features/search/search-command-dialog.tsx
+++ b/src/components/features/search/search-command-dialog.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { Search } from "lucide-react";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
-import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -12,55 +10,41 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useSearchDialogStore } from "@/stores/search-dialog";
 import { SemanticSearchBar } from "./semantic-search-bar";
 
 export function SearchCommandDialog() {
-  const [open, setOpen] = useState(false);
+  const open = useSearchDialogStore((state) => state.open);
+  const setOpen = useSearchDialogStore((state) => state.setOpen);
+  const toggle = useSearchDialogStore((state) => state.toggle);
   const pathname = usePathname();
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
       if ((event.metaKey || event.ctrlKey) && event.key === "k") {
         event.preventDefault();
-        setOpen((prev) => !prev);
+        toggle();
       }
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, []);
+  }, [toggle]);
 
   useEffect(() => {
     setOpen(false);
-  }, [pathname]);
+  }, [pathname, setOpen]);
 
   return (
-    <>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={() => setOpen(true)}
-        aria-label="Ouvrir la recherche"
-        className="text-muted-foreground gap-2"
-      >
-        <Search className="h-4 w-4" />
-        <span className="hidden sm:inline">Rechercher…</span>
-        <kbd className="bg-muted hidden rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold sm:inline">
-          ⌘K
-        </kbd>
-      </Button>
-
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="sm:max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Recherche sémantique</DialogTitle>
-            <DialogDescription>
-              Cherche par sens dans tes notes, tes mémos et le glossaire.
-            </DialogDescription>
-          </DialogHeader>
-          <SemanticSearchBar autoFocus onResultClick={() => setOpen(false)} />
-        </DialogContent>
-      </Dialog>
-    </>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Recherche sémantique</DialogTitle>
+          <DialogDescription>
+            Cherche par sens dans tes notes, tes mémos et le glossaire.
+          </DialogDescription>
+        </DialogHeader>
+        <SemanticSearchBar autoFocus onResultClick={() => setOpen(false)} />
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/features/search/search-trigger-button.tsx
+++ b/src/components/features/search/search-trigger-button.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Search } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useSearchDialogStore } from "@/stores/search-dialog";
+
+export function SearchTriggerButton() {
+  const setOpen = useSearchDialogStore((state) => state.setOpen);
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={() => setOpen(true)}
+      aria-label="Ouvrir la recherche"
+      className="text-muted-foreground gap-2"
+    >
+      <Search className="h-4 w-4" />
+      <span className="hidden sm:inline">Rechercher…</span>
+      <kbd className="bg-muted hidden rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold sm:inline">
+        ⌘K
+      </kbd>
+    </Button>
+  );
+}

--- a/src/stores/search-dialog.ts
+++ b/src/stores/search-dialog.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface SearchDialogState {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+}
+
+export const useSearchDialogStore = create<SearchDialogState>((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+  toggle: () => set((state) => ({ open: !state.open })),
+}));


### PR DESCRIPTION
Fixed: Search command dialog opened twice (duplicate mounted instances) — single store-driven dialog with shared trigger buttons

 Changed: Show landing page anchor links in the header only on the landing page