### PR TITLE
feat(glossary): pipeline YouTube→glossaire + FGC du listing remake

### DIFF
--- a/.claude/skills/glossary-from-youtube/SKILL.md
+++ b/.claude/skills/glossary-from-youtube/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: glossary-from-youtube
+description: Turn a fighting-game matchup YouTube video into glossary entries — one per opposing character, containing only the advice against that character, in FGC language, imported into the ComboTrack glossary. Use when the user gives a YouTube URL and wants the matchup tips summarized and saved. Triggers on "glossary from youtube", "add this matchup to the glossary", "summarize this matchup video".
+argument-hint: <youtube-url> [--lang en] [--cookies chrome] [--publish]
+---
+
+# Glossary from YouTube
+
+Transform a fighting-game tutorial video into reviewed, FGC-native glossary
+entries in the ComboTrack database.
+
+## Pipeline
+
+1. **Transcript** — fetch the video transcript with timestamps (`step-01-transcript.md`)
+2. **Extract** — Claude keeps only the advice against the targeted character(s),
+   one glossary entry per opposing character, in FGC language (`step-02-extract.md`)
+3. **Dedup** — semantic check against the existing glossary, user validates
+   (`step-03-dedup.md`)
+4. **Import** — write entries as drafts, embed for RAG (`step-04-import.md`)
+
+## Flags
+
+- `--lang <code>` — transcript language (default `en`)
+- `--cookies <browser>` — signed-in browser cookies for yt-dlp. **Defaults to
+  `chrome`** (YouTube bot-check). Override (`safari`/`brave`/`firefox`) or
+  disable with `--no-cookies`.
+- `--publish` — import as published instead of draft (default: draft for review)
+
+## Principles
+
+- **Only matchup advice, one entry per opposing character.** Keep only the tips
+  *against* the character(s) the video targets (punishes, how to beat their
+  moves, oki to watch). Drop generic theory and intros. Generic tools (Perfect
+  Parry, late DI…) are described inline within the matchup, never as their own
+  entry.
+- **FGC voice.** Use the vocabulary contract in `.claude/rules/design-system.md`
+  (§ Tone): lab, oki, neutral, punish, BnB, matchup, frame trap, mixup, drive
+  rush. Combo notations in mono (`2MK xx 236P`).
+- **Human in the loop.** Default import is `published: false`. The user reviews
+  in `/admin/glossary` before publishing.
+- **Dedup before write.** Reuse the RAG glossary search so the same concept is
+  not added twice.
+- **Cite the source.** Every entry links back to the video URL.
+
+## Quick start
+
+Load `steps/step-01-transcript.md` and follow each step in order, passing state
+(transcript path, entries JSON path) forward.
+
+## Prerequisites
+
+- Recent `yt-dlp` (`brew install yt-dlp` then keep it updated — stale versions
+  fail with nsig/bot errors)
+- A browser signed into YouTube for `--cookies`
+- `.env` with `OPEN_AI_API_KEY` (embeddings) and `YOUTUBE_API_KEY` (metadata)
+- At least one `ADMIN` user in the database (used as `createdBy`)

--- a/.claude/skills/glossary-from-youtube/steps/step-01-transcript.md
+++ b/.claude/skills/glossary-from-youtube/steps/step-01-transcript.md
@@ -1,0 +1,58 @@
+# Step 1 — Transcript
+
+Goal: get the full transcript of the video with timestamps.
+
+## Action
+
+Run the transcript script (writes JSON to `.claude/output/glossary/`):
+
+```bash
+mkdir -p .claude/output/glossary
+pnpm transcript "<youtube-url>" --lang en --out .claude/output/glossary/transcript.json
+```
+
+> **Quote the URL** (zsh treats `?` and `&` as globs). Cookies default to
+> **Chrome** — YouTube blocks anonymous subtitle requests with "Sign in to
+> confirm you're not a bot" / HTTP 429. Override the browser with
+> `--cookies safari` (or `brave`/`firefox`), or disable with `--no-cookies`.
+
+The script (`scripts/youtube-transcript.ts`) shells out to `yt-dlp`, grabs
+manual subtitles first then auto-generated ones in json3, and produces:
+
+```json
+{
+  "videoId": "…",
+  "url": "https://www.youtube.com/watch?v=…",
+  "language": "en",
+  "segments": [{ "offset": 12, "timestamp": "0:12", "text": "…" }],
+  "fullText": "[0:12] …\n[0:15] …"
+}
+```
+
+## Fallbacks
+
+1. **Bot-check / HTTP 429** — add `--cookies <browser>` (see note above). If it
+   persists, the local `yt-dlp` is stale → `brew upgrade yt-dlp`.
+2. **Wrong / missing language** — retry with another `--lang` (e.g. `--lang ja`,
+   `--lang fr`). Auto-subs usually live under the spoken language code.
+3. **`yt-dlp` not found** — `brew install yt-dlp`.
+4. **No captions at all** — download audio and transcribe with Whisper:
+   ```bash
+   yt-dlp -x --audio-format mp3 -o audio.mp3 "<youtube-url>"
+   ```
+   then transcribe `audio.mp3` (OpenAI Whisper / `whisper.cpp`) and hand the
+   text to step 2 in the same `fullText` shape.
+
+## Also fetch metadata (optional)
+
+`src/lib/youtube.ts` → `getVideoDetails(videoId)` returns title/description/tags
+(needs `YOUTUBE_API_KEY`). Useful to title entries and confirm the game.
+
+## State to carry forward
+
+- `transcript_path` = `.claude/output/glossary/transcript.json`
+- `video_url`, `video_title`
+
+## Next
+
+Read the transcript, then load `steps/step-02-extract.md`.

--- a/.claude/skills/glossary-from-youtube/steps/step-02-extract.md
+++ b/.claude/skills/glossary-from-youtube/steps/step-02-extract.md
@@ -1,0 +1,85 @@
+# Step 2 — Extract matchup advice
+
+Goal: turn the transcript into structured glossary entries that contain **only
+the advice against the character(s) the video targets** — one entry per opposing
+character.
+
+## Read first
+
+- The transcript JSON from step 1 (`fullText` + `segments`).
+- `.claude/rules/design-system.md` § Tone & vocabulary — the FGC vocabulary
+  contract. Use it. No corporate wording.
+
+## How to extract
+
+1. **Identify the opposing character(s)** the video gives advice *against* (the
+   "enumerated" characters — e.g. a "Matchup Express vs Jamie"). Also note the
+   game (SF6, etc.) from the transcript or `getVideoDetails`.
+2. **Keep only the concrete matchup advice** against each character:
+   - punishes (what punishes which move, at what range, with what)
+   - how to beat / contest specific moves (drive rush, fireball, dash-in…)
+   - oki / wake-up and pressure to watch for, gaps to mash, what to bait
+   - anti-airs, whiff punishes, frame situations
+   - **Discard** everything else: intro, outro, "like & subscribe", generic
+     theory not tied to the character, chit-chat.
+3. **One entry per opposing character.** Do **not** create standalone entries for
+   generic mechanics. If a tip uses a generic tool (Perfect Parry, late Drive
+   Impact…), describe it **inline, applied to this matchup**.
+4. Write each entry as a proper **article report** — see "Article style" below.
+
+## Article style
+
+The `content` must read like a well-written, well-spaced matchup article, not a
+dump of fragments. Apply these rules:
+
+- **Open with a framing paragraph** (1–3 sentences): who the character is, why the
+  matchup is tricky, what the article covers.
+- **Themed `###` sections** (e.g. "Punir les drinks", "Gérer le Drive Rush HP",
+  "Oki & corner"). Under each, write **full-sentence prose paragraphs**, not
+  telegraphic bullets.
+- **Spacing:** one blank line between every paragraph and around every heading.
+  Keep paragraphs short (2–4 sentences) so it breathes.
+- **Weave timestamps into the sentence** rather than dropping them at the end:
+  "Quand Jamie boit, tu le punis au `Level 1` (0:24)…".
+- **Bullets only for a genuine short list** of discrete options (e.g. two tools
+  to beat a move) — and each bullet is still a full sentence.
+- **FGC voice:** `lab`, `neutral`, `punish`, `oki`, `frame trap`, `whiff punish`,
+  `mixup`. Inputs / notations in mono: `` `2MK xx 236P` ``, `` `Drive Rush HP` ``.
+- **Accurate:** uncertain frame data gets "≈", never invented. No filler, no
+  corporate wording.
+
+> Optional polish: after writing, you can run `/utils-fix-grammar` on the entry
+> text to tighten spelling and grammar before import.
+
+## Output shape
+
+Write an array to `.claude/output/glossary/entries.json` — one object per
+opposing character:
+
+```json
+[
+  {
+    "title": "Matchup : Jamie (SF6)",
+    "slug": "matchup-jamie-sf6",
+    "category": "Matchup",
+    "excerpt": "Comment jouer le matchup contre Jamie : punir ses drinks, gérer son Drive Rush HP, lire son oki.",
+    "content": "## Matchup : Jamie (SF6)\n\nJamie n'est pas le perso le plus fort, mais il vit sur ses pièges : si tu ne connais pas le matchup, tu te fais ouvrir vite.\n\n### Punir les drinks\n\nJamie boit très souvent pour monter son niveau. La plupart du temps, la `drink` est punissable : avec Ryu tu sors un `Level 1` ou un drive rush punish selon la distance (0:24).\n\n### Drive Rush HP\n\nSon `Drive Rush HP` est rapide, prioritaire et + au block (1:38). Tu le contestes au Perfect Parry en option select, ou en sortant ton Drive Impact le plus tard possible.",
+    "sourceUrl": "https://www.youtube.com/watch?v=…"
+  }
+]
+```
+
+Field rules (match `src/components/features/admin/glossary/article-schema.ts`):
+
+- `title` 3–200 chars · `slug` kebab `[a-z0-9-]` (optional — derived from title)
+- `content` markdown, ≥10 chars · `excerpt` ≤500 chars · `category` required
+- `sourceUrl` — the video URL (appended as a Source line on import)
+
+## Category
+
+Matchup entries use the `Matchup` category. Keep the title pattern
+`Matchup : <Character> (<Game>)` so entries stay consistent and de-dup cleanly.
+
+## Next
+
+Load `steps/step-03-dedup.md`.

--- a/.claude/skills/glossary-from-youtube/steps/step-03-dedup.md
+++ b/.claude/skills/glossary-from-youtube/steps/step-03-dedup.md
@@ -1,0 +1,39 @@
+# Step 3 — Dedup & validate
+
+Goal: avoid adding a concept that already exists, and let the user confirm.
+
+## Action — dry run
+
+Run the import in dry-run mode. It reports, per entry, the semantically closest
+existing glossary articles (cosine ≥ 85%) and the planned action — without
+writing anything:
+
+```bash
+pnpm glossary:import .claude/output/glossary/entries.json --dry-run
+```
+
+Example output:
+
+```
+• Okizeme (oki) (okizeme)
+  ~ proche de "Wakeup / réveil" (wakeup) — 88%
+  → would CREATE
+```
+
+## Decide with the user
+
+For each flagged near-duplicate, present the choice plainly:
+
+- **Merge** → drop the new entry, or improve the existing one (re-run later with
+  `--update` and the existing slug).
+- **Keep both** → distinct enough; proceed.
+- **Skip** → remove the entry from `entries.json`.
+
+Edit `entries.json` to reflect the decisions before importing.
+
+> Note: semantic dedup needs `OPEN_AI_API_KEY`. Without it, only exact-slug
+> collisions are detected — fall back to comparing titles by hand.
+
+## Next
+
+Once `entries.json` is clean, load `steps/step-04-import.md`.

--- a/.claude/skills/glossary-from-youtube/steps/step-04-import.md
+++ b/.claude/skills/glossary-from-youtube/steps/step-04-import.md
@@ -1,0 +1,42 @@
+# Step 4 — Import
+
+Goal: write the entries to the database and embed them for RAG.
+
+## Action
+
+Default — import as **drafts** for review:
+
+```bash
+pnpm glossary:import .claude/output/glossary/entries.json
+```
+
+Update existing articles (merges decided in step 3):
+
+```bash
+pnpm glossary:import .claude/output/glossary/entries.json --update
+```
+
+Publish immediately (skip review — use only when confident):
+
+```bash
+pnpm glossary:import .claude/output/glossary/entries.json --publish
+```
+
+## What the script does
+
+`scripts/glossary-import.ts` mirrors `createArticleAction`:
+
+- picks the oldest `ADMIN` user as `createdBy`
+- checks slug uniqueness (skips, or updates with `--update`)
+- appends a `> Source : <url>` line to the content
+- creates with `published: false` by default
+- embeds the article inline (same vector pipeline as `backfill-embeddings.ts`),
+  so it shows up in semantic search once published
+
+## After import
+
+- Drafts are **not** visible on `/glossary` and **not** returned by semantic
+  search until published.
+- Review and publish in **`/admin/glossary`**.
+
+Report to the user: number created / updated / skipped, and the review link.

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ next-env.d.ts
 .claude/docs/*
 .claude/ideas/*
 .claude/PRD/*
+.claude/output/*
 
 # testing
 /test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-06-11
+
+### Refactor: Redesign glossary listing with FGC design system — card grid, cover slot (image-ready), display/mono typography and chart-token category badges
+
+## 2026-06-08
+
+### Fixed: Glossary article view spacing — markdown renderer now spaces headings, paragraphs and lists
+
+### Added: glossary-from-youtube skill — transcript a fighting-game tutorial into FGC-voiced glossary entries
+
+### Added: `pnpm transcript` script — fetch YouTube transcripts with timestamps via yt-dlp
+
+### Changed: `pnpm transcript` defaults to Chrome cookies (avoids YouTube HTTP 429), with `--cookies <browser>` / `--no-cookies` overrides
+
+### Added: `pnpm glossary:import` script — import structured glossary entries with semantic dedup and RAG embedding
+
 ## 2026-06-04
 
 ### Fixed: Search command dialog opened twice (duplicate mounted instances) — single store-driven dialog with shared trigger buttons

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:all": "pnpm test:run && pnpm test:e2e",
     "backfill:embeddings": "tsx --env-file=.env scripts/backfill-embeddings.ts",
+    "transcript": "tsx --env-file=.env scripts/youtube-transcript.ts",
+    "glossary:import": "tsx --env-file=.env scripts/glossary-import.ts",
     "sync-main": "git checkout main && git pull origin main",
     "commit": "cz",
     "commit:done": "cz && git push && pnpm sync-main && pnpm cleanup",

--- a/scripts/glossary-import.ts
+++ b/scripts/glossary-import.ts
@@ -1,0 +1,228 @@
+/**
+ * Import structured glossary entries into the database.
+ *
+ * Usage:
+ *   pnpm glossary:import <entries.json> [--dry-run] [--update] [--publish]
+ *
+ * Modes:
+ *   --dry-run   Report semantic duplicates and planned actions. No writes.
+ *   --update    Update an existing article when the slug already exists.
+ *               Without it, existing slugs are skipped.
+ *   --publish   Create/update with published = true. Default is draft (false),
+ *               so you review in /admin/glossary before publishing.
+ *
+ * Entries file shape: an array of:
+ *   { title, slug?, category, content, excerpt?, sourceUrl? }
+ *
+ * Mirrors createArticleAction (slug uniqueness, createdBy, embedding) but runs
+ * outside the Better-Auth session, so it embeds inline like backfill-embeddings.
+ */
+import { readFileSync } from "node:fs";
+import { EMBEDDING_MODEL, generateEmbedding } from "../src/lib/ai/openai";
+import { Prisma, prisma } from "../src/lib/prisma";
+import { hashContent } from "../src/lib/rag/content-hash";
+
+type GlossaryEntry = {
+  title: string;
+  slug?: string;
+  category: string;
+  content: string;
+  excerpt?: string;
+  sourceUrl?: string;
+};
+
+type DuplicateMatch = {
+  slug: string;
+  title: string;
+  similarity: number;
+};
+
+const DUPLICATE_THRESHOLD = 0.85;
+
+function parseArgs(): {
+  file: string;
+  dryRun: boolean;
+  update: boolean;
+  publish: boolean;
+} {
+  const argv = process.argv.slice(2);
+  const file = argv.find((arg) => !arg.startsWith("--"));
+
+  if (!file) {
+    console.error(
+      "Usage: pnpm glossary:import <entries.json> [--dry-run] [--update] [--publish]",
+    );
+    process.exit(1);
+  }
+
+  return {
+    file,
+    dryRun: argv.includes("--dry-run"),
+    update: argv.includes("--update"),
+    publish: argv.includes("--publish"),
+  };
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 200);
+}
+
+function composeContent(entry: GlossaryEntry): string {
+  if (!entry.sourceUrl) {
+    return entry.content;
+  }
+  return `${entry.content}\n\n> Source : ${entry.sourceUrl}`;
+}
+
+function toVectorLiteral(embedding: number[]): string {
+  return `[${embedding.join(",")}]`;
+}
+
+async function findSemanticDuplicates(
+  composed: string,
+): Promise<DuplicateMatch[]> {
+  const embedding = await generateEmbedding(composed);
+  if (!embedding) {
+    return [];
+  }
+
+  const vectorCast = Prisma.raw(`'${toVectorLiteral(embedding)}'::vector`);
+
+  const rows = await prisma.$queryRaw<
+    Array<{ slug: string; title: string; distance: number }>
+  >`
+    SELECT "slug", "title", "embedding" <=> ${vectorCast} AS "distance"
+    FROM "glossary_article"
+    WHERE "embedding" IS NOT NULL
+    ORDER BY "embedding" <=> ${vectorCast}
+    LIMIT 3
+  `;
+
+  return rows
+    .map((row) => ({
+      slug: row.slug,
+      title: row.title,
+      similarity: 1 - row.distance,
+    }))
+    .filter((row) => row.similarity >= DUPLICATE_THRESHOLD);
+}
+
+async function embedArticle(
+  id: string,
+  title: string,
+  content: string,
+): Promise<void> {
+  const composed = `${title}\n\n${content}`;
+  const embedding = await generateEmbedding(composed);
+  if (!embedding) {
+    console.warn(`  ⚠ embedding skipped (no OpenAI key) for ${id}`);
+    return;
+  }
+
+  await prisma.$executeRaw`
+    UPDATE "glossary_article"
+    SET "embedding" = ${Prisma.raw(`'${toVectorLiteral(embedding)}'::vector`)},
+        "contentHash" = ${hashContent(composed)},
+        "embeddingModel" = ${EMBEDDING_MODEL}
+    WHERE "id" = ${id}
+  `;
+}
+
+async function main(): Promise<void> {
+  const { file, dryRun, update, publish } = parseArgs();
+  const entries = JSON.parse(readFileSync(file, "utf8")) as GlossaryEntry[];
+
+  console.log(
+    `[glossary] ${entries.length} entries — ${dryRun ? "DRY RUN" : "WRITE"}, ` +
+      `${publish ? "published" : "draft"}, update=${update}`,
+  );
+
+  const admin = await prisma.user.findFirst({
+    where: { role: "ADMIN" },
+    orderBy: { createdAt: "asc" },
+    select: { id: true },
+  });
+
+  if (!admin) {
+    throw new Error("Aucun utilisateur ADMIN trouvé pour createdBy.");
+  }
+
+  for (const entry of entries) {
+    const slug = entry.slug ? slugify(entry.slug) : slugify(entry.title);
+    const content = composeContent(entry);
+
+    const existing = await prisma.glossaryArticle.findUnique({
+      where: { slug },
+      select: { id: true },
+    });
+
+    const duplicates = await findSemanticDuplicates(
+      `${entry.title}\n\n${content}`,
+    );
+    const nearDupes = duplicates.filter((d) => d.slug !== slug);
+
+    console.log(`\n• ${entry.title} (${slug})`);
+    if (nearDupes.length > 0) {
+      for (const dupe of nearDupes) {
+        console.log(
+          `  ~ proche de "${dupe.title}" (${dupe.slug}) — ${(dupe.similarity * 100).toFixed(0)}%`,
+        );
+      }
+    }
+
+    if (dryRun) {
+      console.log(
+        `  → ${existing ? (update ? "would UPDATE" : "would SKIP (slug exists)") : "would CREATE"}`,
+      );
+      continue;
+    }
+
+    if (existing && !update) {
+      console.log("  → SKIP (slug exists, pass --update to overwrite)");
+      continue;
+    }
+
+    const article = existing
+      ? await prisma.glossaryArticle.update({
+          where: { id: existing.id },
+          data: {
+            title: entry.title,
+            content,
+            excerpt: entry.excerpt ?? null,
+            category: entry.category,
+            published: publish,
+          },
+        })
+      : await prisma.glossaryArticle.create({
+          data: {
+            title: entry.title,
+            slug,
+            content,
+            excerpt: entry.excerpt ?? null,
+            category: entry.category,
+            published: publish,
+            createdBy: admin.id,
+          },
+        });
+
+    await embedArticle(article.id, article.title, content);
+    console.log(`  → ${existing ? "UPDATED" : "CREATED"}`);
+  }
+
+  console.log("\n[glossary] done.");
+}
+
+main()
+  .catch((error) => {
+    console.error("[glossary] failed", error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/youtube-transcript.ts
+++ b/scripts/youtube-transcript.ts
@@ -1,0 +1,234 @@
+/**
+ * Fetch a YouTube transcript by URL or video id, with timestamps.
+ *
+ * Usage:
+ *   pnpm transcript "<youtube-url-or-id>" [--lang en] [--out transcript.json]
+ *                   [--cookies chrome | --no-cookies]
+ *
+ * Source: yt-dlp (the most durable method against YouTube changes). It grabs
+ * manual subtitles first, then auto-generated ones, in json3 format.
+ *
+ * Cookies default to Chrome (YouTube 429s anonymous subtitle requests). Override
+ * the browser with `--cookies safari`, or disable with `--no-cookies`.
+ *
+ * Prerequisite: `brew install yt-dlp`
+ * Fallback (no captions at all): download audio with yt-dlp and transcribe
+ * with Whisper — see steps/step-01-transcript.md.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+type Json3Event = {
+  tStartMs?: number;
+  segs?: Array<{ utf8?: string }>;
+};
+
+type TranscriptSegment = {
+  offset: number;
+  timestamp: string;
+  text: string;
+};
+
+type TranscriptResult = {
+  videoId: string;
+  url: string;
+  language: string;
+  segments: TranscriptSegment[];
+  fullText: string;
+};
+
+type Args = {
+  input: string;
+  lang: string;
+  out: string | null;
+  cookies: string | null;
+};
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const input = argv.find((arg) => !arg.startsWith("--"));
+
+  if (!input) {
+    console.error(
+      'Usage: pnpm transcript "<youtube-url-or-id>" [--lang en] [--out file.json] [--cookies chrome | --no-cookies]',
+    );
+    process.exit(1);
+  }
+
+  const langIndex = argv.indexOf("--lang");
+  const outIndex = argv.indexOf("--out");
+
+  return {
+    input,
+    lang: langIndex !== -1 ? (argv[langIndex + 1] ?? "en") : "en",
+    out: outIndex !== -1 ? (argv[outIndex + 1] ?? null) : null,
+    cookies: resolveCookies(argv),
+  };
+}
+
+// Default to Chrome cookies — YouTube 429s anonymous subtitle requests.
+// Override with `--cookies <browser>`, disable with `--no-cookies`.
+function resolveCookies(argv: string[]): string | null {
+  if (argv.includes("--no-cookies")) {
+    return null;
+  }
+  const cookiesIndex = argv.indexOf("--cookies");
+  if (cookiesIndex !== -1) {
+    return argv[cookiesIndex + 1] ?? "chrome";
+  }
+  return "chrome";
+}
+
+const VIDEO_ID = /^[a-zA-Z0-9_-]{11}$/;
+
+function extractVideoId(input: string): string {
+  if (VIDEO_ID.test(input)) {
+    return input;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    throw new Error(
+      `URL invalide : "${input}". Mets l'URL entre guillemets : ` +
+        'pnpm transcript "https://www.youtube.com/watch?v=…"',
+    );
+  }
+
+  // youtube.com/watch?v=ID
+  const fromQuery = url.searchParams.get("v");
+  if (fromQuery && VIDEO_ID.test(fromQuery)) {
+    return fromQuery;
+  }
+
+  // youtu.be/ID, /shorts/ID, /embed/ID, /live/ID
+  const last = url.pathname.split("/").filter(Boolean).at(-1);
+  if (last && VIDEO_ID.test(last)) {
+    return last;
+  }
+
+  throw new Error(
+    `Impossible d'extraire le videoId de "${input}" — URL probablement tronquée. ` +
+      "Mets-la entre guillemets : " +
+      'pnpm transcript "https://www.youtube.com/watch?v=…"',
+  );
+}
+
+function formatTimestamp(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function downloadSubtitles(
+  videoId: string,
+  lang: string,
+  cookies: string | null,
+): string {
+  const dir = mkdtempSync(join(tmpdir(), "yt-transcript-"));
+
+  const args = [
+    "--skip-download",
+    "--write-subs",
+    "--write-auto-subs",
+    "--sub-langs",
+    `${lang}.*,${lang}`,
+    "--sub-format",
+    "json3",
+    "-P",
+    dir,
+    "-o",
+    "%(id)s",
+  ];
+
+  // YouTube bot-check fix: borrow cookies from a signed-in browser.
+  if (cookies) {
+    args.push("--cookies-from-browser", cookies);
+  }
+
+  args.push(`https://www.youtube.com/watch?v=${videoId}`);
+
+  try {
+    execFileSync("yt-dlp", args, { stdio: ["ignore", "ignore", "inherit"] });
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === "ENOENT") {
+      throw new Error("yt-dlp introuvable. Installe-le : brew install yt-dlp");
+    }
+    throw new Error(
+      "yt-dlp a échoué. Causes fréquentes :\n" +
+        "  1. yt-dlp obsolète → brew upgrade yt-dlp (ou pip install -U yt-dlp)\n" +
+        "  2. « Sign in to confirm you're not a bot » → ajoute --cookies chrome " +
+        "(ou safari/brave/firefox)",
+    );
+  }
+
+  const files = readdirSync(dir).filter((f) => f.endsWith(".json3"));
+  if (files.length === 0) {
+    throw new Error(
+      `Aucun sous-titre trouvé pour ${videoId} (langue ${lang}). ` +
+        "Essaie une autre --lang, ou utilise le fallback Whisper (voir step-01).",
+    );
+  }
+
+  const preferred = files.find((f) => f.includes(`.${lang}.`)) ?? files[0];
+  return readFileSync(join(dir, preferred), "utf8");
+}
+
+function parseJson3(raw: string): TranscriptSegment[] {
+  const data = JSON.parse(raw) as { events?: Json3Event[] };
+  const segments: TranscriptSegment[] = [];
+
+  for (const event of data.events ?? []) {
+    if (!event.segs) {
+      continue;
+    }
+    const text = event.segs
+      .map((seg) => seg.utf8 ?? "")
+      .join("")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    if (!text) {
+      continue;
+    }
+
+    const offset = Math.floor((event.tStartMs ?? 0) / 1000);
+    segments.push({ offset, timestamp: formatTimestamp(offset), text });
+  }
+
+  return segments;
+}
+
+function main(): void {
+  const { input, lang, out, cookies } = parseArgs();
+  const videoId = extractVideoId(input);
+
+  console.error(`[transcript] fetching ${videoId} (lang ${lang})…`);
+
+  const raw = downloadSubtitles(videoId, lang, cookies);
+  const segments = parseJson3(raw);
+  const fullText = segments.map((s) => `[${s.timestamp}] ${s.text}`).join("\n");
+
+  const result: TranscriptResult = {
+    videoId,
+    url: `https://www.youtube.com/watch?v=${videoId}`,
+    language: lang,
+    segments,
+    fullText,
+  };
+
+  const payload = JSON.stringify(result, null, 2);
+
+  if (out) {
+    writeFileSync(out, payload, "utf8");
+    console.error(`[transcript] ${segments.length} segments written to ${out}`);
+  } else {
+    process.stdout.write(payload);
+  }
+}
+
+main();

--- a/src/components/features/glossary/glossary-article-card.tsx
+++ b/src/components/features/glossary/glossary-article-card.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 import type { PublishedArticles } from "../../../../prisma/query/glossary.query";
 import { CategoryBadge } from "./glossary-category-badge";
@@ -7,36 +7,64 @@ interface ArticleCardProps {
   article: PublishedArticles[number];
 }
 
+function formatDate(date: Date) {
+  return new Date(date).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
 export function ArticleCard({ article }: ArticleCardProps) {
   return (
-    <Link href={`/glossary/${article.slug}`}>
-      <Card className="text-muted-foreground cursor-pointer rounded-xl border border-zinc-800 bg-zinc-900/50 px-1 py-4 backdrop-blur transition-all hover:-translate-y-0.5 hover:border-zinc-700 hover:bg-zinc-900 hover:shadow-lg">
-        <CardHeader>
-          <CardTitle className="flex w-full items-center justify-between">
-            <div className="flex items-center gap-2">
-              {article.category && (
-                <CategoryBadge category={article.category} />
-              )}
-              <span className="text-foreground text-lg">{article.title}</span>
-            </div>
-            <div className="text-sm font-light">
-              {new Date(article.createdAt).toLocaleDateString()}
-            </div>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          {article.excerpt ? (
-            <p className="text-muted-foreground text-sm">{article.excerpt}</p>
-          ) : (
-            <p className="text-muted-foreground text-sm italic">
-              Aucune description disponible
-            </p>
+    <Link
+      href={`/glossary/${article.slug}`}
+      className="group block focus:outline-none"
+    >
+      <article className="bg-card border-border hover:border-primary/60 focus-visible:border-primary/60 hover:shadow-primary/25 relative flex h-full flex-col overflow-hidden rounded-lg border transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_10px_40px_-15px]">
+        {/* Cover — placeholder until per-article images land.
+            Replace this block with <img src={article.image} … /> once the field exists. */}
+        <div className="bg-muted border-border relative aspect-[16/9] w-full overflow-hidden border-b">
+          {article.category && (
+            <span className="font-display text-foreground/[0.05] absolute inset-0 flex items-center justify-center px-4 text-center text-4xl tracking-tight uppercase select-none">
+              {article.category}
+            </span>
           )}
-          <p className="text-muted-foreground text-xs">
-            Par {article.creator.name}
+
+          {/* FGC corner ticks */}
+          <span className="border-primary/40 absolute top-2 left-2 h-3 w-3 border-t border-l" />
+          <span className="border-primary/40 absolute top-2 right-2 h-3 w-3 border-t border-r" />
+          <span className="border-primary/40 absolute bottom-2 left-2 h-3 w-3 border-b border-l" />
+          <span className="border-primary/40 absolute right-2 bottom-2 h-3 w-3 border-r border-b" />
+
+          {article.category && (
+            <div className="absolute top-3 left-3">
+              <CategoryBadge category={article.category} />
+            </div>
+          )}
+          <span className="text-muted-foreground absolute right-3 bottom-3 font-mono text-[11px] tabular-nums">
+            {formatDate(article.createdAt)}
+          </span>
+        </div>
+
+        {/* Body */}
+        <div className="flex flex-1 flex-col gap-3 p-5">
+          <h3 className="font-display text-foreground group-hover:text-primary text-base leading-tight tracking-tight uppercase transition-colors">
+            {article.title}
+          </h3>
+          <p className="text-muted-foreground line-clamp-3 text-sm leading-relaxed">
+            {article.excerpt ?? "Aucune description disponible"}
           </p>
-        </CardContent>
-      </Card>
+          <div className="border-border mt-auto flex items-center justify-between border-t pt-3">
+            <span className="text-muted-foreground font-mono text-[11px]">
+              Par {article.creator.name}
+            </span>
+            <span className="text-primary inline-flex translate-x-1 items-center gap-1 text-xs font-medium opacity-0 transition-all group-hover:translate-x-0 group-hover:opacity-100">
+              Lire <ArrowUpRight className="h-3.5 w-3.5" />
+            </span>
+          </div>
+        </div>
+      </article>
     </Link>
   );
 }

--- a/src/components/features/glossary/glossary-article-detail.tsx
+++ b/src/components/features/glossary/glossary-article-detail.tsx
@@ -29,8 +29,57 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
         </div>
       </header>
 
-      <div className="prose prose-invert max-w-none">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+      <div className="max-w-none text-[15px] leading-relaxed">
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={{
+            h1: ({ children }) => (
+              <h1 className="mt-8 mb-4 text-2xl font-bold first:mt-0">
+                {children}
+              </h1>
+            ),
+            h2: ({ children }) => (
+              <h2 className="mt-8 mb-3 text-2xl font-bold first:mt-0">
+                {children}
+              </h2>
+            ),
+            h3: ({ children }) => (
+              <h3 className="mt-6 mb-2 text-xl font-semibold">{children}</h3>
+            ),
+            p: ({ children }) => (
+              <p className="mb-4 leading-relaxed">{children}</p>
+            ),
+            ul: ({ children }) => (
+              <ul className="mb-4 list-disc space-y-2 pl-6">{children}</ul>
+            ),
+            ol: ({ children }) => (
+              <ol className="mb-4 list-decimal space-y-2 pl-6">{children}</ol>
+            ),
+            li: ({ children }) => (
+              <li className="leading-relaxed">{children}</li>
+            ),
+            a: ({ href, children }) => (
+              <a href={href} className="text-primary underline">
+                {children}
+              </a>
+            ),
+            strong: ({ children }) => (
+              <strong className="text-foreground font-semibold">
+                {children}
+              </strong>
+            ),
+            code: ({ children }) => (
+              <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-sm">
+                {children}
+              </code>
+            ),
+            blockquote: ({ children }) => (
+              <blockquote className="border-border text-muted-foreground my-4 border-l-2 pl-4 italic">
+                {children}
+              </blockquote>
+            ),
+          }}
+        >
           {article.content}
         </ReactMarkdown>
       </div>

--- a/src/components/features/glossary/glossary-category-badge.tsx
+++ b/src/components/features/glossary/glossary-category-badge.tsx
@@ -1,4 +1,3 @@
-import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 interface CategoryBadgeProps {
@@ -6,33 +5,39 @@ interface CategoryBadgeProps {
   className?: string;
 }
 
-const getCategoryColor = (category: string) => {
-  const colors = [
-    "border-violet-500/20 bg-violet-500/10 text-violet-400",
-    "border-emerald-500/20 bg-emerald-500/10 text-emerald-400",
-    "border-blue-500/20 bg-blue-500/10 text-blue-400",
-    "border-amber-500/20 bg-amber-500/10 text-amber-400",
-    "border-rose-500/20 bg-rose-500/10 text-rose-400",
-    "border-cyan-500/20 bg-cyan-500/10 text-cyan-400",
-  ];
+// FGC-aligned chart tokens (defined in globals.css) instead of raw Tailwind colors.
+const CHART_VARS = [
+  "--chart-1",
+  "--chart-2",
+  "--chart-3",
+  "--chart-4",
+  "--chart-5",
+] as const;
 
+function categoryAccent(category: string): string {
   let hash = 0;
   for (let i = 0; i < category.length; i++) {
     hash = category.charCodeAt(i) + ((hash << 5) - hash);
   }
-
-  return colors[Math.abs(hash) % colors.length];
-};
+  return `var(${CHART_VARS[Math.abs(hash) % CHART_VARS.length]})`;
+}
 
 export function CategoryBadge({ category, className }: CategoryBadgeProps) {
-  const colorClass = getCategoryColor(category);
+  const accent = categoryAccent(category);
 
   return (
-    <Badge
-      variant="outline"
-      className={cn("rounded-full", colorClass, className)}
+    <span
+      className={cn(
+        "border-border/60 bg-background/70 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-[10px] tracking-wider uppercase backdrop-blur",
+        className,
+      )}
+      style={{ color: accent }}
     >
-      {category.charAt(0).toUpperCase() + category.slice(1)}
-    </Badge>
+      <span
+        className="h-1.5 w-1.5 rounded-full"
+        style={{ backgroundColor: accent }}
+      />
+      {category}
+    </span>
   );
 }

--- a/src/components/features/glossary/glossary-list.tsx
+++ b/src/components/features/glossary/glossary-list.tsx
@@ -16,25 +16,37 @@ export function GlossaryList({
     : articles;
 
   return (
-    <div className="space-y-4">
-      <h2 className="text-2xl font-bold">Glossaire</h2>
+    <section className="space-y-8">
+      <header className="border-border space-y-3 border-b pb-6">
+        <p className="font-display text-primary text-xs tracking-[0.2em] uppercase">
+          FGC // Base de connaissances
+        </p>
+        <div className="flex items-end justify-between gap-4">
+          <h1 className="font-display text-foreground text-4xl tracking-tight uppercase">
+            Glossaire
+          </h1>
+          <span className="text-muted-foreground font-mono text-sm tabular-nums">
+            {filteredArticles.length.toString().padStart(2, "0")} entrées
+          </span>
+        </div>
+      </header>
 
       {filteredArticles.length === 0 ? (
-        <div className="text-muted-foreground py-12 text-center">
-          <BookOpen className="mx-auto mb-4 h-12 w-12" />
-          <p>
+        <div className="border-border text-muted-foreground flex flex-col items-center rounded-lg border border-dashed py-16 text-center">
+          <BookOpen className="mb-4 h-10 w-10 opacity-50" />
+          <p className="font-mono text-sm">
             {selectedCategory
               ? "Aucun article dans cette catégorie."
               : "Aucun article disponible pour le moment."}
           </p>
         </div>
       ) : (
-        <div className="space-y-3">
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {filteredArticles.map((article) => (
             <ArticleCard key={article.id} article={article} />
           ))}
         </div>
       )}
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
- skill glossary-from-youtube (SKILL.md + 4 steps)
- scripts: pnpm transcript (yt-dlp, cookies par défaut) + pnpm glossary:import (Prisma, dédup sémantique, embed)
- fix: espacement de la vue article (markdown renderer)
- refactor: listing glossaire en design system FGC (grille, cover image-ready, badges chart-token)