### PR TITLE
Glossary article cover image upload with R2 storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## 2026-06-11
 
+### Fixed: Server Action body size limit set to 2mb — image uploads over the 1mb default no longer rejected
+
+### Fixed: Mount Sonner Toaster in root layout — toasts now render app-wide
+
+### Added: Client-side size/format validation on glossary image upload with error toast
+
+### Added: Glossary article cover image upload (R2 storage) with edit-form field and card rendering
+
 ### Refactor: Redesign glossary listing with FGC design system — card grid, cover slot (image-ready), display/mono typography and chart-token category badges
 
 ## 2026-06-08

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Footer } from "@/components/features/landing/footer";
 import { Header } from "@/components/features/landing/header";
 import { ThemeProvider } from "@/components/theme-provider";
+import { Toaster } from "@/components/ui/sonner";
 import { websiteConfig } from "@/config/website-config";
 import type { Metadata } from "next";
 import { Geist, JetBrains_Mono } from "next/font/google";
@@ -46,6 +47,7 @@ export default function RootLayout({
             <main className="flex-1">{children}</main>
             <Footer />
           </div>
+          <Toaster />
         </ThemeProvider>
       </body>
     </html>

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "2mb",
+    },
+  },
 };
 
 export default nextConfig;

--- a/prisma/migrations/20260611120000_add_glossary_article_image/migration.sql
+++ b/prisma/migrations/20260611120000_add_glossary_article_image/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "glossary_article" ADD COLUMN "image" TEXT;

--- a/prisma/query/admin-glossary.query.ts
+++ b/prisma/query/admin-glossary.query.ts
@@ -31,6 +31,7 @@ export const getArticleByIdForAdmin = async (id: string) =>
       content: true,
       excerpt: true,
       category: true,
+      image: true,
       published: true,
       createdAt: true,
       updatedAt: true,

--- a/prisma/query/glossary.query.ts
+++ b/prisma/query/glossary.query.ts
@@ -13,6 +13,7 @@ export const getAllPublishedArticles = async (category?: string) =>
       title: true,
       excerpt: true,
       category: true,
+      image: true,
       createdAt: true,
       creator: {
         select: {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -211,6 +211,7 @@ model GlossaryArticle {
   content        String                       @db.Text
   excerpt        String?
   category       String?
+  image          String?
   published      Boolean                      @default(false)
   embedding      Unsupported("vector(1536)")?
   contentHash    String?

--- a/src/components/features/admin/glossary/article-action.ts
+++ b/src/components/features/admin/glossary/article-action.ts
@@ -11,7 +11,8 @@ import z from "zod";
 export const createArticleAction = adminActionClient
   .inputSchema(createArticleSchema)
   .action(async ({ parsedInput, ctx }) => {
-    const { title, slug, content, excerpt, category, published } = parsedInput;
+    const { title, slug, content, excerpt, category, image, published } =
+      parsedInput;
 
     // Check slug uniqueness
     const existing = await prisma.glossaryArticle.findUnique({
@@ -29,6 +30,7 @@ export const createArticleAction = adminActionClient
         content,
         excerpt,
         category,
+        image: image ?? null,
         published,
         createdBy: ctx.user.id,
       },
@@ -51,7 +53,7 @@ export const createArticleAction = adminActionClient
 export const updateArticleAction = adminActionClient
   .inputSchema(updateArticleSchema)
   .action(async ({ parsedInput }) => {
-    const { id, title, slug, content, excerpt, category, published } =
+    const { id, title, slug, content, excerpt, category, image, published } =
       parsedInput;
 
     // Check slug uniqueness (excluding current article)
@@ -74,6 +76,7 @@ export const updateArticleAction = adminActionClient
         content,
         excerpt,
         category,
+        image: image ?? null,
         published,
       },
     });

--- a/src/components/features/admin/glossary/article-form.tsx
+++ b/src/components/features/admin/glossary/article-form.tsx
@@ -23,6 +23,7 @@ import { Button } from "@/components/ui/button";
 import { articleFormSchema, ArticleFormSchemaType } from "./article-schema";
 import { createArticleAction, updateArticleAction } from "./article-action";
 import { MarkdownPreview } from "./markdown-preview";
+import { ImageField } from "./image-field";
 import { AdminArticleDetail } from "@/../prisma/query/admin-glossary.query";
 
 interface ArticleFormProps {
@@ -84,6 +85,7 @@ export function ArticleForm({ mode, article }: ArticleFormProps) {
       content: article?.content ?? "",
       excerpt: article?.excerpt ?? "",
       category: article?.category ?? "",
+      image: article?.image ?? "",
       published: article?.published ?? false,
     },
   });
@@ -162,6 +164,26 @@ export function ArticleForm({ mode, article }: ArticleFormProps) {
                       placeholder="Ex: Techniques, Personnages, Termes"
                     />
                   </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="image"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Image de couverture</FormLabel>
+                  <FormControl>
+                    <ImageField
+                      value={field.value ?? ""}
+                      onChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Affichée dans la liste des articles (optionnel)
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/src/components/features/admin/glossary/article-schema.ts
+++ b/src/components/features/admin/glossary/article-schema.ts
@@ -22,6 +22,7 @@ export const articleFormSchema = z.object({
     .optional()
     .or(z.literal("")),
   category: z.string().min(1, "La catégorie est requise"),
+  image: z.string().url("L'image doit être une URL valide").optional().or(z.literal("")),
   published: z.boolean(),
 });
 

--- a/src/components/features/admin/glossary/image-field.tsx
+++ b/src/components/features/admin/glossary/image-field.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { ImageIcon, Loader2, X } from "lucide-react";
+import { useState, type ChangeEvent } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { uploadGlossaryImageAction } from "@/lib/actions/upload-glossary-image";
+
+interface ImageFieldProps {
+  value?: string;
+  onChange: (url: string) => void;
+}
+
+export function ImageField({ value, onChange }: ImageFieldProps) {
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+
+    if (!file) {
+      return;
+    }
+
+    if (file.size > 2 * 1024 * 1024) {
+      toast.error("L'image doit faire moins de 2 Mo");
+      return;
+    }
+
+    if (!["image/jpeg", "image/png", "image/webp"].includes(file.type)) {
+      toast.error("Formats acceptés : JPEG, PNG, WebP");
+      return;
+    }
+
+    setIsUploading(true);
+
+    const formData = new FormData();
+    formData.append("image", file);
+
+    const result = await uploadGlossaryImageAction(formData);
+
+    setIsUploading(false);
+
+    if (!result.success || !result.imageUrl) {
+      toast.error(result.error ?? "Échec de l'upload de l'image");
+      return;
+    }
+
+    onChange(result.imageUrl);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="bg-muted border-border relative aspect-[16/9] w-full overflow-hidden rounded-lg border">
+        {value ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={value}
+            alt="Aperçu"
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="text-muted-foreground absolute inset-0 flex flex-col items-center justify-center gap-2">
+            <ImageIcon className="h-8 w-8" />
+            <span className="text-sm">Aucune image</span>
+          </div>
+        )}
+
+        {value && (
+          <Button
+            type="button"
+            variant="destructive"
+            size="icon"
+            className="absolute top-2 right-2 h-7 w-7"
+            onClick={() => onChange("")}
+            disabled={isUploading}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      <div>
+        <input
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          onChange={handleFileChange}
+          className="hidden"
+          id="glossary-image-upload"
+          disabled={isUploading}
+        />
+        <label htmlFor="glossary-image-upload">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={isUploading}
+            onClick={() =>
+              document.getElementById("glossary-image-upload")?.click()
+            }
+          >
+            {isUploading ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <ImageIcon className="mr-2 h-4 w-4" />
+            )}
+            {value ? "Changer l'image" : "Choisir une image"}
+          </Button>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/glossary/glossary-article-card.tsx
+++ b/src/components/features/glossary/glossary-article-card.tsx
@@ -22,13 +22,21 @@ export function ArticleCard({ article }: ArticleCardProps) {
       className="group block focus:outline-none"
     >
       <article className="bg-card border-border hover:border-primary/60 focus-visible:border-primary/60 hover:shadow-primary/25 relative flex h-full flex-col overflow-hidden rounded-lg border transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_10px_40px_-15px]">
-        {/* Cover — placeholder until per-article images land.
-            Replace this block with <img src={article.image} … /> once the field exists. */}
+        {/* Cover — article image when present, otherwise category watermark. */}
         <div className="bg-muted border-border relative aspect-[16/9] w-full overflow-hidden border-b">
-          {article.category && (
-            <span className="font-display text-foreground/[0.05] absolute inset-0 flex items-center justify-center px-4 text-center text-4xl tracking-tight uppercase select-none">
-              {article.category}
-            </span>
+          {article.image ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={article.image}
+              alt={article.title}
+              className="absolute inset-0 h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+            />
+          ) : (
+            article.category && (
+              <span className="font-display text-foreground/[0.05] absolute inset-0 flex items-center justify-center px-4 text-center text-4xl tracking-tight uppercase select-none">
+                {article.category}
+              </span>
+            )
           )}
 
           {/* FGC corner ticks */}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, ToasterProps } from "sonner";
 

--- a/src/lib/actions/upload-glossary-image.ts
+++ b/src/lib/actions/upload-glossary-image.ts
@@ -1,0 +1,65 @@
+"use server";
+
+import { requireAdmin } from "@/lib/auth-utils";
+import { env } from "@/lib/env";
+import { s3Client } from "@/lib/s3-client";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { z } from "zod";
+
+const imageSchema = z.object({
+  file: z
+    .instanceof(File)
+    .refine(
+      (file) => file.size <= 2 * 1024 * 1024,
+      "Image must be less than 2MB",
+    )
+    .refine(
+      (file) => ["image/jpeg", "image/png", "image/webp"].includes(file.type),
+      "Only JPEG, PNG, and WebP images are allowed",
+    ),
+});
+
+export async function uploadGlossaryImageAction(formData: FormData) {
+  try {
+    await requireAdmin();
+
+    const file = formData.get("image") as File | null;
+
+    if (!file) {
+      return { success: false, error: "No file provided" };
+    }
+
+    const validation = imageSchema.safeParse({ file });
+
+    if (!validation.success) {
+      return {
+        success: false,
+        error: validation.error.issues[0]?.message ?? "Invalid file",
+      };
+    }
+
+    const ext = file.type.split("/")[1];
+    const filename = `glossary/${crypto.randomUUID()}-${Date.now()}.${ext}`;
+
+    const bytes = await file.arrayBuffer();
+    const buffer = Buffer.from(bytes);
+
+    await s3Client.send(
+      new PutObjectCommand({
+        Bucket: env.AWS_S3_BUCKET_NAME,
+        Key: filename,
+        Body: buffer,
+        ContentType: file.type,
+      }),
+    );
+
+    const imageUrl = `${env.R2_URL}/${filename}`;
+
+    return { success: true, imageUrl };
+  } catch {
+    return {
+      success: false,
+      error: "Failed to upload image. Please try again.",
+    };
+  }
+}


### PR DESCRIPTION
## Summary

• Add image upload feature to glossary articles with R2/S3 storage
• Image field component with 16:9 preview, client-side validation (< 2mb, JPEG/PNG/WebP)
• Server Action body limit increased to 2mb for file uploads
• Display cover images on article cards, fallback to category watermark
• Fixed Sonner Toaster not rendering app-wide (added "use client" directive)

## Changes

- `schema.prisma`: Add `image` field to GlossaryArticle
- `prisma/migrations/`: Add image column via migration
- `src/lib/actions/upload-glossary-image.ts`: New server action for R2 upload
- `src/components/features/admin/glossary/image-field.tsx`: New image upload component
- `article-form.tsx`, `article-action.ts`, `article-schema.ts`: Integrated image field
- `glossary-article-card.tsx`: Render image or fallback to category watermark
- `next.config.ts`: Set `serverActions.bodySizeLimit` to 2mb
- `app/layout.tsx`, `src/components/ui/sonner.tsx`: Fix Toaster rendering

## Type

feat