### PR TITLE
Add inline image upload and hero cover to glossary articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-06-12
+
+### Added: Inline image upload in glossary article content — insert button injects markdown, images render in editor preview and consultation view
+
+### Added: Glossary article cover image hero at top of consultation view when present
+
 ## 2026-06-11
 
 ### Fixed: Server Action body size limit set to 2mb — image uploads over the 1mb default no longer rejected

--- a/prisma/query/glossary.query.ts
+++ b/prisma/query/glossary.query.ts
@@ -36,6 +36,7 @@ export const getArticleBySlug = async (slug: string) =>
       title: true,
       content: true,
       category: true,
+      image: true,
       createdAt: true,
       updatedAt: true,
       creator: {

--- a/src/components/features/admin/glossary/article-form.tsx
+++ b/src/components/features/admin/glossary/article-form.tsx
@@ -24,6 +24,7 @@ import { articleFormSchema, ArticleFormSchemaType } from "./article-schema";
 import { createArticleAction, updateArticleAction } from "./article-action";
 import { MarkdownPreview } from "./markdown-preview";
 import { ImageField } from "./image-field";
+import { ContentField } from "./content-field";
 import { AdminArticleDetail } from "@/../prisma/query/admin-glossary.query";
 
 interface ArticleFormProps {
@@ -218,14 +219,14 @@ export function ArticleForm({ mode, article }: ArticleFormProps) {
                 <FormItem>
                   <FormLabel>Contenu (Markdown)</FormLabel>
                   <FormControl>
-                    <Textarea
-                      {...field}
-                      placeholder="Contenu de l'article en markdown..."
-                      className="min-h-[300px] font-mono"
+                    <ContentField
+                      value={field.value}
+                      onChange={field.onChange}
                     />
                   </FormControl>
                   <FormDescription>
-                    Utilisez la syntaxe Markdown pour formater le contenu
+                    Utilisez la syntaxe Markdown pour formater le contenu.
+                    Insérez des images directement dans le texte.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/src/components/features/admin/glossary/content-field.tsx
+++ b/src/components/features/admin/glossary/content-field.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { ImageIcon, Loader2 } from "lucide-react";
+import { useRef, useState, type ChangeEvent } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { uploadGlossaryImageAction } from "@/lib/actions/upload-glossary-image";
+
+interface ContentFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function ContentField({ value, onChange }: ContentFieldProps) {
+  const [isUploading, setIsUploading] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const insertAtCursor = (text: string) => {
+    const textarea = textareaRef.current;
+
+    if (!textarea) {
+      onChange(value + text);
+      return;
+    }
+
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const before = value.slice(0, start);
+    const after = value.slice(end);
+    const newValue = before + text + after;
+
+    onChange(newValue);
+
+    const newCursorPos = start + text.length;
+
+    requestAnimationFrame(() => {
+      textarea.focus();
+      textarea.setSelectionRange(newCursorPos, newCursorPos);
+    });
+  };
+
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+
+    if (!file) {
+      return;
+    }
+
+    if (file.size > 2 * 1024 * 1024) {
+      toast.error("L'image doit faire moins de 2 Mo");
+      return;
+    }
+
+    if (!["image/jpeg", "image/png", "image/webp"].includes(file.type)) {
+      toast.error("Formats acceptés : JPEG, PNG, WebP");
+      return;
+    }
+
+    setIsUploading(true);
+
+    const formData = new FormData();
+    formData.append("image", file);
+
+    const result = await uploadGlossaryImageAction(formData);
+
+    setIsUploading(false);
+
+    if (!result.success || !result.imageUrl) {
+      toast.error(result.error ?? "Échec de l'upload de l'image");
+      return;
+    }
+
+    const alt = file.name.replace(/\.[^.]+$/, "");
+    insertAtCursor(`\n\n![${alt}](${result.imageUrl})\n\n`);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <input
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          onChange={handleFileChange}
+          className="hidden"
+          id="glossary-content-image-upload"
+          disabled={isUploading}
+        />
+        <label htmlFor="glossary-content-image-upload">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={isUploading}
+            onClick={() =>
+              document.getElementById("glossary-content-image-upload")?.click()
+            }
+          >
+            {isUploading ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <ImageIcon className="mr-2 h-4 w-4" />
+            )}
+            Insérer une image
+          </Button>
+        </label>
+      </div>
+
+      <Textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Contenu de l'article en markdown..."
+        className="min-h-[300px] font-mono"
+      />
+    </div>
+  );
+}

--- a/src/components/features/admin/glossary/markdown-preview.tsx
+++ b/src/components/features/admin/glossary/markdown-preview.tsx
@@ -10,7 +10,19 @@ interface MarkdownPreviewProps {
 export function MarkdownPreview({ content }: MarkdownPreviewProps) {
   return (
     <div className="prose prose-invert border-border bg-card text-accent-foreground max-w-none rounded-lg border p-4">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          img: ({ src, alt }) => (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={typeof src === "string" ? src : undefined}
+              alt={alt ?? ""}
+              className="border-border my-4 w-full rounded-lg border"
+            />
+          ),
+        }}
+      >
         {content || "*Aucun contenu à prévisualiser*"}
       </ReactMarkdown>
     </div>

--- a/src/components/features/glossary/glossary-article-detail.tsx
+++ b/src/components/features/glossary/glossary-article-detail.tsx
@@ -13,6 +13,17 @@ interface ArticleDetailProps {
 export function ArticleDetail({ article }: ArticleDetailProps) {
   return (
     <article className="space-y-6">
+      {article.image && (
+        <div className="bg-muted border-border relative aspect-[16/9] w-full overflow-hidden rounded-lg border">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={article.image}
+            alt={article.title}
+            className="absolute inset-0 h-full w-full object-cover"
+          />
+        </div>
+      )}
+
       <header className="space-y-4">
         <h1 className="text-4xl font-bold">{article.title}</h1>
 
@@ -77,6 +88,14 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
               <blockquote className="border-border text-muted-foreground my-4 border-l-2 pl-4 italic">
                 {children}
               </blockquote>
+            ),
+            img: ({ src, alt }) => (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={typeof src === "string" ? src : undefined}
+                alt={alt ?? ""}
+                className="border-border my-6 w-full rounded-lg border"
+              />
             ),
           }}
         >


### PR DESCRIPTION
## Summary

• Inline image upload in article editor — insert button injects markdown syntax
• Live preview renders images in editor  
• Cover image displays as hero section at top of published article
• Inline content images render with markdown processor in consultation view
• Reuses existing R2 storage and upload action

## Type

feat