### PR TITLE
feat(notation): FGC notation rendering + dropdown insertion (memo, matrix, glossary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-06-20
+
+### Added: Colored FGC button rendering (LP/MP/HP → blue/yellow/red) in inline-code notation across memo, strategy matrix cell editor and grid previews
+
+### Added: Motion input rendering as directional arrow glyphs (236→↓↘→, 623, 214…) with hover labels in notation
+
+### Added: Motion notation dropdown (236/623/214…) with arrow-glyph labels in memo and strategy matrix cell editors
+
+### Changed: Notation/Motion/Frames dropdowns now auto-wrap inserted tokens into inline-code so notation renders colored without typing backticks
+
+### Changed: Inserting a button from the notation dropdown closes the inline-code zone and adds a trailing space outside the backtick for readability
+
 ## 2026-06-12
 
 ### Added: Inline image upload in glossary article content — insert button injects markdown, images render in editor preview and consultation view
@@ -60,7 +72,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added: Branded CT favicon (app/icon.svg + multi-size favicon.ico) matching the header logo badge
 
-### Refactor: Rebuild footer to match header identity (CT logo badge, font-display title, fgc-* palette, mono link columns, hairline accent)
+### Refactor: Rebuild footer to match header identity (CT logo badge, font-display title, fgc-\* palette, mono link columns, hairline accent)
 
 ### Added: Dashboard command-center hero with FGC training-room identity (eyebrow, font-display greeting, ⌘K trigger, resource panel)
 
@@ -78,13 +90,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added: Design tokens for frame advantage (--frame-positive/negative/neutral), match status (--status-draft/in-progress/completed/analyzed) and note template categories (--tag-offense/defense/neutral/mental/execution/okizeme)
 
-### Refactor: Frame data renderer now uses --frame-* tokens instead of hardcoded text-blue/red/yellow
+### Refactor: Frame data renderer now uses --frame-\* tokens instead of hardcoded text-blue/red/yellow
 
-### Refactor: Note template selector uses --tag-* tokens with single-color semantic styling (drops dark: modifier on color)
+### Refactor: Note template selector uses --tag-\* tokens with single-color semantic styling (drops dark: modifier on color)
 
 ### Refactor: Dashboard hero carousel gradient uses FGC accent palette instead of orange-red-pink
 
-### Refactor: Replay card status and duration badges use --status-* and --fgc-accent tokens
+### Refactor: Replay card status and duration badges use --status-\* and --fgc-accent tokens
 
 ### Fixed: Glossary article detail footer border uses --border instead of hardcoded zinc-800
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-06-21
+
+### Added: FGC notation toolbar in the glossary article editor, with colored rendering in the admin preview and the public article view
+
 ## 2026-06-20
 
 ### Added: Colored FGC button rendering (LP/MP/HP → blue/yellow/red) in inline-code notation across memo, strategy matrix cell editor and grid previews

--- a/app/globals.css
+++ b/app/globals.css
@@ -56,6 +56,11 @@
   --frame-negative: oklch(0.65 0.2 28);
   --frame-neutral: oklch(0.78 0.15 80);
 
+  /* Notation FGC — button intensity (light/medium/heavy) */
+  --notation-light: oklch(0.72 0.13 220);
+  --notation-medium: oklch(0.78 0.15 80);
+  --notation-heavy: oklch(0.65 0.2 28);
+
   /* Match status — used on replay cards */
   --status-draft: oklch(0.6 0 0);
   --status-in-progress: oklch(0.7 0.2 28);
@@ -203,6 +208,10 @@ body {
   --color-frame-positive: var(--frame-positive);
   --color-frame-negative: var(--frame-negative);
   --color-frame-neutral: var(--frame-neutral);
+
+  --color-notation-light: var(--notation-light);
+  --color-notation-medium: var(--notation-medium);
+  --color-notation-heavy: var(--notation-heavy);
 
   --color-status-draft: var(--status-draft);
   --color-status-in-progress: var(--status-in-progress);

--- a/src/components/features/admin/glossary/content-field.tsx
+++ b/src/components/features/admin/glossary/content-field.tsx
@@ -4,6 +4,7 @@ import { ImageIcon, Loader2 } from "lucide-react";
 import { useRef, useState, type ChangeEvent } from "react";
 import { toast } from "sonner";
 
+import { NotationToolbar } from "@/components/features/notation/notation-toolbar";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { uploadGlossaryImageAction } from "@/lib/actions/upload-glossary-image";
@@ -79,7 +80,12 @@ export function ContentField({ value, onChange }: ContentFieldProps) {
 
   return (
     <div className="space-y-2">
-      <div>
+      <div className="flex flex-wrap items-center gap-2">
+        <NotationToolbar
+          textareaRef={textareaRef}
+          value={value}
+          onValueChange={onChange}
+        />
         <input
           type="file"
           accept="image/jpeg,image/png,image/webp"

--- a/src/components/features/admin/glossary/markdown-preview.tsx
+++ b/src/components/features/admin/glossary/markdown-preview.tsx
@@ -3,6 +3,8 @@
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import { notationComponents } from "@/components/features/notation/notation-renderer";
+
 interface MarkdownPreviewProps {
   content: string;
 }
@@ -13,6 +15,7 @@ export function MarkdownPreview({ content }: MarkdownPreviewProps) {
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
+          ...notationComponents,
           img: ({ src, alt }) => (
             // eslint-disable-next-line @next/next/no-img-element
             <img

--- a/src/components/features/glossary/glossary-article-detail.tsx
+++ b/src/components/features/glossary/glossary-article-detail.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { renderInlineNotation } from "@/components/features/notation/notation-renderer";
+import { highlightFrameData } from "@/components/features/strategy-matrix/frame-data-renderer";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -58,7 +60,9 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
               <h3 className="mt-6 mb-2 text-xl font-semibold">{children}</h3>
             ),
             p: ({ children }) => (
-              <p className="mb-4 leading-relaxed">{children}</p>
+              <p className="mb-4 leading-relaxed">
+                {highlightFrameData(children)}
+              </p>
             ),
             ul: ({ children }) => (
               <ul className="mb-4 list-disc space-y-2 pl-6">{children}</ul>
@@ -67,7 +71,9 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
               <ol className="mb-4 list-decimal space-y-2 pl-6">{children}</ol>
             ),
             li: ({ children }) => (
-              <li className="leading-relaxed">{children}</li>
+              <li className="leading-relaxed">
+                {highlightFrameData(children)}
+              </li>
             ),
             a: ({ href, children }) => (
               <a href={href} className="text-primary underline">
@@ -79,11 +85,15 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
                 {children}
               </strong>
             ),
-            code: ({ children }) => (
-              <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-sm">
-                {children}
-              </code>
-            ),
+            code: ({ className, children }) =>
+              className && /language-/.test(className) ? (
+                <code className={className}>{children}</code>
+              ) : (
+                renderInlineNotation(
+                  children,
+                  "bg-muted rounded px-1.5 py-0.5 font-mono text-sm",
+                )
+              ),
             blockquote: ({ children }) => (
               <blockquote className="border-border text-muted-foreground my-4 border-l-2 pl-4 italic">
                 {children}

--- a/src/components/features/memo/memo-form.tsx
+++ b/src/components/features/memo/memo-form.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import { frameDataComponents } from "@/components/features/strategy-matrix/frame-data-renderer";
-import {
-  FGC_ACTIONS,
-  FGC_BUTTONS,
-  FGC_POSITIONS,
-  FRAME_OPTIONS,
-} from "@/components/features/strategy-matrix/strategy-matrix-types";
+import { notationComponents } from "@/components/features/notation/notation-renderer";
+import { NotationToolbar } from "@/components/features/notation/notation-toolbar";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -17,15 +12,6 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Eye, Pencil } from "lucide-react";
@@ -58,20 +44,14 @@ type Props =
 export function MemoForm(props: Props) {
   const router = useRouter();
   const [showPreview, setShowPreview] = useState(false);
-  const [notationKey, setNotationKey] = useState(0);
-  const [frameKey, setFrameKey] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const form = useForm<MemoFormInput>({
     resolver: zodResolver(memoFormSchema),
     defaultValues:
-      props.mode === "edit"
-        ? props.initialData
-        : { title: "", content: "" },
+      props.mode === "edit" ? props.initialData : { title: "", content: "" },
     mode: "onSubmit",
   });
-
-  const content = form.watch("content");
 
   const createAction = useAction(createMemoAction, {
     onSuccess: ({ data }) => {
@@ -94,27 +74,6 @@ export function MemoForm(props: Props) {
   });
 
   const isPending = createAction.isPending || updateAction.isPending;
-
-  const insertAtCursor = (text: string, cursorOffset?: number) => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-
-    const start = textarea.selectionStart;
-    const end = textarea.selectionEnd;
-    const before = content.slice(0, start);
-    const after = content.slice(end);
-    const newContent = (before + text + after).slice(0, MAX_MEMO_CONTENT_LENGTH);
-
-    form.setValue("content", newContent, { shouldDirty: true });
-
-    const newCursorPos =
-      cursorOffset !== undefined ? start + cursorOffset : start + text.length;
-
-    requestAnimationFrame(() => {
-      textarea.focus();
-      textarea.setSelectionRange(newCursorPos, newCursorPos);
-    });
-  };
 
   const onSubmit = (data: MemoFormInput) => {
     if (props.mode === "edit") {
@@ -174,69 +133,12 @@ export function MemoForm(props: Props) {
               </div>
 
               {!showPreview && (
-                <div className="flex items-center gap-2">
-                  <Select
-                    key={`notation-${notationKey}`}
-                    onValueChange={(v) => {
-                      insertAtCursor(v);
-                      setNotationKey((k) => k + 1);
-                    }}
-                  >
-                    <SelectTrigger size="sm" className="w-auto text-xs">
-                      <SelectValue placeholder="Notation..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        <SelectLabel>Positions</SelectLabel>
-                        {FGC_POSITIONS.map((item) => (
-                          <SelectItem key={item.value} value={item.value}>
-                            {item.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                      <SelectGroup>
-                        <SelectLabel>Boutons</SelectLabel>
-                        {FGC_BUTTONS.map((item) => (
-                          <SelectItem key={item.value} value={item.value}>
-                            {item.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                      <SelectGroup>
-                        <SelectLabel>Actions</SelectLabel>
-                        {FGC_ACTIONS.map((item) => (
-                          <SelectItem key={item.value} value={item.value}>
-                            {item.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-
-                  <Select
-                    key={`frame-${frameKey}`}
-                    onValueChange={(v) => {
-                      const option = FRAME_OPTIONS.find((o) => o.value === v);
-                      const offset =
-                        option && "cursorOffset" in option
-                          ? (option as { cursorOffset: number }).cursorOffset
-                          : undefined;
-                      insertAtCursor(v, offset);
-                      setFrameKey((k) => k + 1);
-                    }}
-                  >
-                    <SelectTrigger size="sm" className="w-auto text-xs">
-                      <SelectValue placeholder="Frames..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {FRAME_OPTIONS.map((item) => (
-                        <SelectItem key={item.value} value={item.value}>
-                          {item.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
+                <NotationToolbar
+                  textareaRef={textareaRef}
+                  value={field.value}
+                  onValueChange={(next) => field.onChange(next)}
+                  maxLength={MAX_MEMO_CONTENT_LENGTH}
+                />
               )}
 
               <FormControl>
@@ -244,7 +146,7 @@ export function MemoForm(props: Props) {
                   <div className="prose prose-invert border-border bg-muted text-foreground min-h-[200px] max-w-none rounded-md border p-3 text-sm">
                     <ReactMarkdown
                       remarkPlugins={[remarkGfm]}
-                      components={frameDataComponents}
+                      components={notationComponents}
                     >
                       {field.value || "*Aucun contenu*"}
                     </ReactMarkdown>

--- a/src/components/features/notation/notation-chip.tsx
+++ b/src/components/features/notation/notation-chip.tsx
@@ -1,0 +1,62 @@
+import { FGC_BUTTONS } from "@/components/features/strategy-matrix/strategy-matrix-types";
+import { cn } from "@/lib/utils";
+import type {
+  ButtonIntensity,
+  FrameTone,
+  NotationSegment,
+} from "./notation-parser";
+
+const BUTTON_INTENSITY_CLASS: Record<ButtonIntensity, string> = {
+  light: "text-notation-light bg-notation-light/15",
+  medium: "text-notation-medium bg-notation-medium/15",
+  heavy: "text-notation-heavy bg-notation-heavy/15",
+  neutral: "text-foreground bg-muted",
+};
+
+const FRAME_TONE_CLASS: Record<FrameTone, string> = {
+  positive: "text-frame-positive",
+  negative: "text-frame-negative",
+  neutral: "text-frame-neutral",
+};
+
+type Props = {
+  segment: NotationSegment;
+};
+
+export function NotationChip({ segment }: Props) {
+  if (segment.kind === "button") {
+    const label =
+      FGC_BUTTONS.find((button) => button.value === segment.raw)?.label ??
+      segment.raw;
+
+    return (
+      <span
+        title={label}
+        className={cn(
+          "inline-flex items-center rounded px-1 py-0.5 text-[0.85em] leading-none font-semibold",
+          BUTTON_INTENSITY_CLASS[segment.intensity],
+        )}
+      >
+        {segment.raw}
+      </span>
+    );
+  }
+
+  if (segment.kind === "motion") {
+    return (
+      <span title={segment.label ?? undefined} className="font-semibold">
+        {segment.glyphs ?? segment.raw}
+      </span>
+    );
+  }
+
+  if (segment.kind === "frame") {
+    return (
+      <span className={cn("font-semibold", FRAME_TONE_CLASS[segment.tone])}>
+        {segment.raw}
+      </span>
+    );
+  }
+
+  return <>{segment.raw}</>;
+}

--- a/src/components/features/notation/notation-parser.test.ts
+++ b/src/components/features/notation/notation-parser.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { numpadToGlyphs, parseNotation } from "./notation-parser";
+
+describe("numpadToGlyphs", () => {
+  it("maps a quarter-circle-forward motion to arrow glyphs", () => {
+    expect(numpadToGlyphs("236")).toBe("↓↘→");
+  });
+
+  it("returns null when a digit is not directional (contains 0)", () => {
+    expect(numpadToGlyphs("360")).toBeNull();
+  });
+});
+
+describe("parseNotation", () => {
+  it("recognizes intensity buttons with the right color tier", () => {
+    expect(parseNotation("HP")).toEqual([
+      { kind: "button", raw: "HP", intensity: "heavy" },
+    ]);
+    expect(parseNotation("LP")).toEqual([
+      { kind: "button", raw: "LP", intensity: "light" },
+    ]);
+    expect(parseNotation("MK")).toEqual([
+      { kind: "button", raw: "MK", intensity: "medium" },
+    ]);
+  });
+
+  it("renders a generic button as a neutral chip", () => {
+    expect(parseNotation("236K")).toEqual([
+      {
+        kind: "motion",
+        raw: "236",
+        glyphs: "↓↘→",
+        label: expect.stringContaining("QCF"),
+      },
+      { kind: "button", raw: "K", intensity: "neutral" },
+    ]);
+  });
+
+  it("attaches glyphs and a label to a known motion", () => {
+    const [motion] = parseNotation("236");
+    expect(motion).toMatchObject({
+      kind: "motion",
+      raw: "236",
+      glyphs: "↓↘→",
+    });
+    expect(motion).toHaveProperty("label", expect.stringContaining("avant"));
+  });
+
+  it("prefers the longest known motion (41236 over 236)", () => {
+    expect(parseNotation("41236P")).toEqual([
+      {
+        kind: "motion",
+        raw: "41236",
+        glyphs: "←↙↓↘→",
+        label: expect.stringContaining("HCF"),
+      },
+      { kind: "button", raw: "P", intensity: "neutral" },
+    ]);
+  });
+
+  it("combines a motion and a button (236HP)", () => {
+    expect(parseNotation("236HP")).toEqual([
+      {
+        kind: "motion",
+        raw: "236",
+        glyphs: "↓↘→",
+        label: expect.stringContaining("QCF"),
+      },
+      { kind: "button", raw: "HP", intensity: "heavy" },
+    ]);
+  });
+
+  it("colors frame data inside the code and does not treat +8 as a motion", () => {
+    const segments = parseNotation("HP (+8)");
+    expect(segments).toContainEqual({
+      kind: "frame",
+      raw: "(+8)",
+      tone: "positive",
+    });
+    expect(segments.some((s) => s.kind === "motion")).toBe(false);
+  });
+
+  it("does not mistake a super art (SA1) for a motion", () => {
+    const segments = parseNotation("SA1");
+    expect(segments.some((s) => s.kind === "motion")).toBe(false);
+  });
+
+  it("keeps plain notation operators and positions as text", () => {
+    expect(parseNotation("cr. xx >")).toEqual([
+      { kind: "text", raw: "cr. xx >" },
+    ]);
+  });
+
+  it("renders a motion with a 0 as raw text with its label", () => {
+    expect(parseNotation("360P")).toEqual([
+      {
+        kind: "motion",
+        raw: "360",
+        glyphs: null,
+        label: expect.stringContaining("SPD"),
+      },
+      { kind: "button", raw: "P", intensity: "neutral" },
+    ]);
+  });
+
+  it("does not match a single button letter inside a word", () => {
+    expect(parseNotation("Punch")).toEqual([{ kind: "text", raw: "Punch" }]);
+  });
+});

--- a/src/components/features/notation/notation-parser.ts
+++ b/src/components/features/notation/notation-parser.ts
@@ -1,0 +1,106 @@
+import { FGC_MOTIONS } from "@/components/features/strategy-matrix/strategy-matrix-types";
+
+export const NUMPAD_GLYPHS: Record<string, string> = {
+  "1": "↙",
+  "2": "↓",
+  "3": "↘",
+  "4": "←",
+  "5": "‧",
+  "6": "→",
+  "7": "↖",
+  "8": "↑",
+  "9": "↗",
+};
+
+export function numpadToGlyphs(numpad: string): string | null {
+  let glyphs = "";
+  for (const char of numpad) {
+    const glyph = NUMPAD_GLYPHS[char];
+    if (!glyph) return null;
+    glyphs += glyph;
+  }
+  return glyphs;
+}
+
+export type ButtonIntensity = "light" | "medium" | "heavy" | "neutral";
+export type FrameTone = "positive" | "negative" | "neutral";
+
+export type NotationSegment =
+  | { kind: "button"; raw: string; intensity: ButtonIntensity }
+  | { kind: "motion"; raw: string; glyphs: string | null; label: string | null }
+  | { kind: "frame"; raw: string; tone: FrameTone }
+  | { kind: "text"; raw: string };
+
+const FRAME_SOURCE = String.raw`\([+-]\d{1,2}\)|\(0\)`;
+const INTENSITY_BUTTON_SOURCE = `LP|MP|HP|LK|MK|HK`;
+const GENERIC_BUTTON_SOURCE = String.raw`(?:PPP|KKK|PP|KK|P|K)(?![A-Za-z])`;
+const KNOWN_MOTION_SOURCE = [...FGC_MOTIONS]
+  .map((motion) => motion.value)
+  .sort((a, b) => b.length - a.length)
+  .join("|");
+const GENERIC_MOTION_SOURCE = String.raw`[1-9]{2,5}`;
+
+const NOTATION_PATTERN = new RegExp(
+  `(${FRAME_SOURCE})|(${INTENSITY_BUTTON_SOURCE})|(${GENERIC_BUTTON_SOURCE})|(${KNOWN_MOTION_SOURCE})|(${GENERIC_MOTION_SOURCE})`,
+  "g",
+);
+
+function frameTone(raw: string): FrameTone {
+  if (raw.includes("+")) return "positive";
+  if (raw.includes("-")) return "negative";
+  return "neutral";
+}
+
+function buttonIntensity(raw: string): ButtonIntensity {
+  const first = raw[0];
+  if (first === "L") return "light";
+  if (first === "M") return "medium";
+  if (first === "H") return "heavy";
+  return "neutral";
+}
+
+function motionLabel(raw: string): string | null {
+  return FGC_MOTIONS.find((motion) => motion.value === raw)?.label ?? null;
+}
+
+export function parseNotation(input: string): NotationSegment[] {
+  const segments: NotationSegment[] = [];
+  let lastIndex = 0;
+
+  for (const match of input.matchAll(NOTATION_PATTERN)) {
+    const index = match.index ?? 0;
+    if (index > lastIndex) {
+      segments.push({ kind: "text", raw: input.slice(lastIndex, index) });
+    }
+
+    const [full, frame, intensity, generic, knownMotion, genericMotion] = match;
+
+    if (frame) {
+      segments.push({ kind: "frame", raw: frame, tone: frameTone(frame) });
+    } else if (intensity) {
+      segments.push({
+        kind: "button",
+        raw: intensity,
+        intensity: buttonIntensity(intensity),
+      });
+    } else if (generic) {
+      segments.push({ kind: "button", raw: generic, intensity: "neutral" });
+    } else {
+      const raw = knownMotion ?? genericMotion;
+      segments.push({
+        kind: "motion",
+        raw,
+        glyphs: numpadToGlyphs(raw),
+        label: motionLabel(raw),
+      });
+    }
+
+    lastIndex = index + full.length;
+  }
+
+  if (lastIndex < input.length) {
+    segments.push({ kind: "text", raw: input.slice(lastIndex) });
+  }
+
+  return segments;
+}

--- a/src/components/features/notation/notation-renderer.tsx
+++ b/src/components/features/notation/notation-renderer.tsx
@@ -1,0 +1,36 @@
+import { frameDataComponents } from "@/components/features/strategy-matrix/frame-data-renderer";
+import type { ReactNode } from "react";
+import type { Components } from "react-markdown";
+import { NotationChip } from "./notation-chip";
+import { parseNotation } from "./notation-parser";
+
+function childrenToString(children: ReactNode): string {
+  if (typeof children === "string") return children;
+  if (typeof children === "number") return String(children);
+  if (Array.isArray(children)) return children.map(childrenToString).join("");
+  return "";
+}
+
+export const notationComponents: Partial<Components> = {
+  ...frameDataComponents,
+  code({ className, children }) {
+    if (className && /language-/.test(className)) {
+      return <code className={className}>{children}</code>;
+    }
+
+    const segments = parseNotation(childrenToString(children));
+    const hasNotation = segments.some((segment) => segment.kind !== "text");
+
+    if (!hasNotation) {
+      return <code>{children}</code>;
+    }
+
+    return (
+      <span className="font-mono">
+        {segments.map((segment, index) => (
+          <NotationChip key={index} segment={segment} />
+        ))}
+      </span>
+    );
+  },
+};

--- a/src/components/features/notation/notation-renderer.tsx
+++ b/src/components/features/notation/notation-renderer.tsx
@@ -11,6 +11,26 @@ function childrenToString(children: ReactNode): string {
   return "";
 }
 
+export function renderInlineNotation(
+  children: ReactNode,
+  fallbackClassName?: string,
+): ReactNode {
+  const segments = parseNotation(childrenToString(children));
+  const hasNotation = segments.some((segment) => segment.kind !== "text");
+
+  if (!hasNotation) {
+    return <code className={fallbackClassName}>{children}</code>;
+  }
+
+  return (
+    <span className="font-mono">
+      {segments.map((segment, index) => (
+        <NotationChip key={index} segment={segment} />
+      ))}
+    </span>
+  );
+}
+
 export const notationComponents: Partial<Components> = {
   ...frameDataComponents,
   code({ className, children }) {
@@ -18,19 +38,6 @@ export const notationComponents: Partial<Components> = {
       return <code className={className}>{children}</code>;
     }
 
-    const segments = parseNotation(childrenToString(children));
-    const hasNotation = segments.some((segment) => segment.kind !== "text");
-
-    if (!hasNotation) {
-      return <code>{children}</code>;
-    }
-
-    return (
-      <span className="font-mono">
-        {segments.map((segment, index) => (
-          <NotationChip key={index} segment={segment} />
-        ))}
-      </span>
-    );
+    return renderInlineNotation(children);
   },
 };

--- a/src/components/features/notation/notation-toolbar.tsx
+++ b/src/components/features/notation/notation-toolbar.tsx
@@ -24,7 +24,7 @@ type Props = {
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   value: string;
   onValueChange: (next: string) => void;
-  maxLength: number;
+  maxLength?: number;
 };
 
 export function NotationToolbar({

--- a/src/components/features/notation/notation-toolbar.tsx
+++ b/src/components/features/notation/notation-toolbar.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import {
+  FGC_ACTIONS,
+  FGC_BUTTONS,
+  FGC_MOTIONS,
+  FGC_POSITIONS,
+  FRAME_OPTIONS,
+} from "@/components/features/strategy-matrix/strategy-matrix-types";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { insertNotationToken } from "@/lib/insert-notation";
+import { useState, type RefObject } from "react";
+import { numpadToGlyphs } from "./notation-parser";
+
+type Props = {
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  value: string;
+  onValueChange: (next: string) => void;
+  maxLength: number;
+};
+
+export function NotationToolbar({
+  textareaRef,
+  value,
+  onValueChange,
+  maxLength,
+}: Props) {
+  const [notationKey, setNotationKey] = useState(0);
+  const [motionKey, setMotionKey] = useState(0);
+  const [frameKey, setFrameKey] = useState(0);
+
+  const handleInsert = (
+    token: string,
+    opts?: { cursorOffset?: number; closeZone?: boolean },
+  ) => {
+    const textarea = textareaRef.current;
+    const start = textarea?.selectionStart ?? value.length;
+    const end = textarea?.selectionEnd ?? value.length;
+
+    const result = insertNotationToken(value, start, end, token, {
+      cursorOffset: opts?.cursorOffset,
+      closeZone: opts?.closeZone,
+      maxLength,
+    });
+
+    onValueChange(result.value);
+
+    requestAnimationFrame(() => {
+      textarea?.focus();
+      textarea?.setSelectionRange(result.cursor, result.cursor);
+    });
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Select
+        key={`notation-${notationKey}`}
+        onValueChange={(v) => {
+          handleInsert(v, {
+            closeZone: FGC_BUTTONS.some((button) => button.value === v),
+          });
+          setNotationKey((k) => k + 1);
+        }}
+      >
+        <SelectTrigger size="sm" className="w-auto text-xs">
+          <SelectValue placeholder="Notation..." />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectLabel>Positions</SelectLabel>
+            {FGC_POSITIONS.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+          <SelectGroup>
+            <SelectLabel>Boutons</SelectLabel>
+            {FGC_BUTTONS.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+          <SelectGroup>
+            <SelectLabel>Actions</SelectLabel>
+            {FGC_ACTIONS.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+
+      <Select
+        key={`motion-${motionKey}`}
+        onValueChange={(v) => {
+          handleInsert(v);
+          setMotionKey((k) => k + 1);
+        }}
+      >
+        <SelectTrigger size="sm" className="w-auto text-xs">
+          <SelectValue placeholder="Motion..." />
+        </SelectTrigger>
+        <SelectContent>
+          {FGC_MOTIONS.map((item) => {
+            const glyphs = numpadToGlyphs(item.value);
+            return (
+              <SelectItem key={item.value} value={item.value}>
+                {glyphs ? `${glyphs}  ${item.label}` : item.label}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+
+      <Select
+        key={`frame-${frameKey}`}
+        onValueChange={(v) => {
+          const option = FRAME_OPTIONS.find((o) => o.value === v);
+          const offset =
+            option && "cursorOffset" in option
+              ? (option as { cursorOffset: number }).cursorOffset
+              : undefined;
+          handleInsert(v, { cursorOffset: offset });
+          setFrameKey((k) => k + 1);
+        }}
+      >
+        <SelectTrigger size="sm" className="w-auto text-xs">
+          <SelectValue placeholder="Frames..." />
+        </SelectTrigger>
+        <SelectContent>
+          {FRAME_OPTIONS.map((item) => (
+            <SelectItem key={item.value} value={item.value}>
+              {item.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/components/features/strategy-matrix/frame-data-renderer.tsx
+++ b/src/components/features/strategy-matrix/frame-data-renderer.tsx
@@ -4,7 +4,7 @@ import { Fragment } from "react";
 
 const FRAME_PATTERN = /(\([+-]\d{1,2}\)|\(0\))/g;
 
-function highlightFrameData(children: ReactNode): ReactNode {
+export function highlightFrameData(children: ReactNode): ReactNode {
   if (typeof children === "string") {
     const parts = children.split(FRAME_PATTERN);
     if (parts.length === 1) return children;

--- a/src/components/features/strategy-matrix/strategy-matrix-cell-editor.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-cell-editor.tsx
@@ -20,28 +20,14 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Eye, Pencil } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { frameDataComponents } from "./frame-data-renderer";
+import { notationComponents } from "@/components/features/notation/notation-renderer";
+import { NotationToolbar } from "@/components/features/notation/notation-toolbar";
 import { FrameLegend } from "./frame-legend";
-import {
-  FGC_ACTIONS,
-  FGC_BUTTONS,
-  FGC_POSITIONS,
-  FRAME_OPTIONS,
-  MAX_CELL_LENGTH,
-} from "./strategy-matrix-types";
+import { MAX_CELL_LENGTH } from "./strategy-matrix-types";
 
 type Props = {
   open: boolean;
@@ -63,8 +49,6 @@ export function StrategyMatrixCellEditor({
   const [content, setContent] = useState(initialContent);
   const [showPreview, setShowPreview] = useState(false);
   const [confirmCloseOpen, setConfirmCloseOpen] = useState(false);
-  const [notationKey, setNotationKey] = useState(0);
-  const [frameKey, setFrameKey] = useState(0);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -74,27 +58,6 @@ export function StrategyMatrixCellEditor({
       setConfirmCloseOpen(false);
     }
   }, [open, initialContent]);
-
-  const insertAtCursor = (text: string, cursorOffset?: number) => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-
-    const start = textarea.selectionStart;
-    const end = textarea.selectionEnd;
-    const before = content.slice(0, start);
-    const after = content.slice(end);
-    const newContent = (before + text + after).slice(0, MAX_CELL_LENGTH);
-
-    setContent(newContent);
-
-    const newCursorPos =
-      cursorOffset !== undefined ? start + cursorOffset : start + text.length;
-
-    requestAnimationFrame(() => {
-      textarea.focus();
-      textarea.setSelectionRange(newCursorPos, newCursorPos);
-    });
-  };
 
   const isDirty = content !== initialContent;
 
@@ -189,76 +152,19 @@ export function StrategyMatrixCellEditor({
             </div>
 
             {!showPreview && (
-              <div className="flex items-center gap-2">
-                <Select
-                  key={`notation-${notationKey}`}
-                  onValueChange={(v) => {
-                    insertAtCursor(v);
-                    setNotationKey((k) => k + 1);
-                  }}
-                >
-                  <SelectTrigger size="sm" className="w-auto text-xs">
-                    <SelectValue placeholder="Notation..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      <SelectLabel>Positions</SelectLabel>
-                      {FGC_POSITIONS.map((item) => (
-                        <SelectItem key={item.value} value={item.value}>
-                          {item.label}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                    <SelectGroup>
-                      <SelectLabel>Boutons</SelectLabel>
-                      {FGC_BUTTONS.map((item) => (
-                        <SelectItem key={item.value} value={item.value}>
-                          {item.label}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                    <SelectGroup>
-                      <SelectLabel>Actions</SelectLabel>
-                      {FGC_ACTIONS.map((item) => (
-                        <SelectItem key={item.value} value={item.value}>
-                          {item.label}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-
-                <Select
-                  key={`frame-${frameKey}`}
-                  onValueChange={(v) => {
-                    const option = FRAME_OPTIONS.find((o) => o.value === v);
-                    const offset =
-                      option && "cursorOffset" in option
-                        ? (option as { cursorOffset: number }).cursorOffset
-                        : undefined;
-                    insertAtCursor(v, offset);
-                    setFrameKey((k) => k + 1);
-                  }}
-                >
-                  <SelectTrigger size="sm" className="w-auto text-xs">
-                    <SelectValue placeholder="Frames..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {FRAME_OPTIONS.map((item) => (
-                      <SelectItem key={item.value} value={item.value}>
-                        {item.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+              <NotationToolbar
+                textareaRef={textareaRef}
+                value={content}
+                onValueChange={setContent}
+                maxLength={MAX_CELL_LENGTH}
+              />
             )}
 
             {showPreview ? (
               <div className="prose prose-invert border-border bg-muted text-foreground min-h-[200px] max-w-none rounded-md border p-3 text-sm">
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
-                  components={frameDataComponents}
+                  components={notationComponents}
                 >
                   {content || "*Aucun contenu*"}
                 </ReactMarkdown>

--- a/src/components/features/strategy-matrix/strategy-matrix-grid.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-grid.tsx
@@ -3,7 +3,7 @@
 import { cn } from "@/lib/utils";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { frameDataComponents } from "./frame-data-renderer";
+import { notationComponents } from "@/components/features/notation/notation-renderer";
 import type { Axis, Cell } from "./strategy-matrix-schema";
 import { buildCellLookup, cellKey } from "./strategy-matrix-types";
 
@@ -88,7 +88,7 @@ export function StrategyMatrixGrid({
                     <div className="prose prose-invert prose-sm line-clamp-5 max-w-none [&_*]:my-0 [&_li]:leading-snug [&_p]:leading-snug">
                       <ReactMarkdown
                         remarkPlugins={[remarkGfm]}
-                        components={frameDataComponents}
+                        components={notationComponents}
                       >
                         {content}
                       </ReactMarkdown>

--- a/src/components/features/strategy-matrix/strategy-matrix-types.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-types.ts
@@ -42,6 +42,20 @@ export const FGC_ACTIONS: NotationItem[] = [
   { value: "Backdash", label: "Backdash" },
 ];
 
+export const FGC_MOTIONS: NotationItem[] = [
+  { value: "236", label: "236 (Quart de cercle avant / QCF)" },
+  { value: "214", label: "214 (Quart de cercle arrière / QCB)" },
+  { value: "623", label: "623 (Dragon punch / DP)" },
+  { value: "421", label: "421 (Reverse DP)" },
+  { value: "41236", label: "41236 (Demi-cercle avant / HCF)" },
+  { value: "63214", label: "63214 (Demi-cercle arrière / HCB)" },
+  { value: "22", label: "22 (Double bas)" },
+  { value: "66", label: "66 (Dash avant)" },
+  { value: "44", label: "44 (Backdash)" },
+  { value: "360", label: "360 (Tour complet / SPD)" },
+  { value: "720", label: "720 (Double tour)" },
+];
+
 export const FRAME_OPTIONS = [
   { value: "(+)", label: "Avantage (+)", cursorOffset: 2 },
   { value: "(-)", label: "Désavantage (-)", cursorOffset: 2 },

--- a/src/lib/insert-notation.test.ts
+++ b/src/lib/insert-notation.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { insertNotationToken } from "./insert-notation";
+
+describe("insertNotationToken", () => {
+  it("wraps the token in backticks when inserting into prose", () => {
+    expect(insertNotationToken("", 0, 0, "236", { maxLength: 2000 })).toEqual({
+      value: "`236`",
+      cursor: 4,
+    });
+  });
+
+  it("places the cursor inside the new zone (before the closing backtick)", () => {
+    const { value, cursor } = insertNotationToken("", 0, 0, "HP", {
+      maxLength: 2000,
+    });
+    expect(value).toBe("`HP`");
+    expect(value[cursor]).toBe("`");
+  });
+
+  it("extends the current zone without adding backticks when already inside", () => {
+    expect(
+      insertNotationToken("`cr.`", 4, 4, "HP", { maxLength: 2000 }),
+    ).toEqual({
+      value: "`cr.HP`",
+      cursor: 6,
+    });
+  });
+
+  it("keeps the cursor between the parentheses for frame tokens", () => {
+    expect(
+      insertNotationToken("", 0, 0, "(+)", {
+        cursorOffset: 2,
+        maxLength: 2000,
+      }),
+    ).toEqual({
+      value: "`(+)`",
+      cursor: 3,
+    });
+  });
+
+  it("replaces the current selection", () => {
+    expect(
+      insertNotationToken("abXYcd", 2, 4, "HP", { maxLength: 2000 }),
+    ).toEqual({
+      value: "ab`HP`cd",
+      cursor: 5,
+    });
+  });
+
+  it("starts a fresh zone when a closed combo already exists earlier on the line", () => {
+    expect(
+      insertNotationToken("`cr.HP` ", 8, 8, "236", { maxLength: 2000 }),
+    ).toEqual({
+      value: "`cr.HP` `236`",
+      cursor: 12,
+    });
+  });
+
+  it("clamps the result to maxLength", () => {
+    const { value } = insertNotationToken("", 0, 0, "236", { maxLength: 3 });
+    expect(value.length).toBe(3);
+  });
+
+  it("closes the zone with a trailing space outside the backtick in prose", () => {
+    expect(
+      insertNotationToken("", 0, 0, "HP", {
+        closeZone: true,
+        maxLength: 2000,
+      }),
+    ).toEqual({
+      value: "`HP` ",
+      cursor: 5,
+    });
+  });
+
+  it("closes the current zone and adds a trailing space when inside", () => {
+    expect(
+      insertNotationToken("`cr.`", 4, 4, "HP", {
+        closeZone: true,
+        maxLength: 2000,
+      }),
+    ).toEqual({
+      value: "`cr.HP` ",
+      cursor: 8,
+    });
+  });
+});

--- a/src/lib/insert-notation.ts
+++ b/src/lib/insert-notation.ts
@@ -1,0 +1,65 @@
+type InsertNotationOptions = {
+  cursorOffset?: number;
+  closeZone?: boolean;
+  maxLength: number;
+};
+
+type InsertNotationResult = {
+  value: string;
+  cursor: number;
+};
+
+function isInsideInlineCode(before: string): boolean {
+  const line = before.slice(before.lastIndexOf("\n") + 1);
+  let backticks = 0;
+  for (const char of line) {
+    if (char === "`") backticks += 1;
+  }
+  return backticks % 2 === 1;
+}
+
+export function insertNotationToken(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  token: string,
+  options: InsertNotationOptions,
+): InsertNotationResult {
+  const before = value.slice(0, selectionStart);
+  const after = value.slice(selectionEnd);
+  const inside = isInsideInlineCode(before);
+
+  if (options.closeZone) {
+    let head: string;
+    let tail: string;
+
+    if (inside) {
+      const closeIndex = after.indexOf("`");
+      if (closeIndex !== -1) {
+        head = before + token + after.slice(0, closeIndex + 1) + " ";
+        tail = after.slice(closeIndex + 1);
+      } else {
+        head = before + token + "` ";
+        tail = after;
+      }
+    } else {
+      head = before + `\`${token}\` `;
+      tail = after;
+    }
+
+    const nextValue = (head + tail).slice(0, options.maxLength);
+    return {
+      value: nextValue,
+      cursor: Math.min(head.length, nextValue.length),
+    };
+  }
+
+  const insertText = inside ? token : `\`${token}\``;
+  const wrapOpen = inside ? 0 : 1;
+
+  const nextValue = (before + insertText + after).slice(0, options.maxLength);
+  const offset = options.cursorOffset ?? token.length;
+  const cursor = Math.min(selectionStart + wrapOpen + offset, nextValue.length);
+
+  return { value: nextValue, cursor };
+}

--- a/src/lib/insert-notation.ts
+++ b/src/lib/insert-notation.ts
@@ -1,7 +1,7 @@
 type InsertNotationOptions = {
   cursorOffset?: number;
   closeZone?: boolean;
-  maxLength: number;
+  maxLength?: number;
 };
 
 type InsertNotationResult = {


### PR DESCRIPTION
## Summary

Implements the **Top 3** from the brainstorm `.claude/ideas/2026-06-20-editeur-prise-de-note.md`: visual rendering of FGC notation + "auto-notation" dropdown insertion, across the 3 editing surfaces (memo, strategy matrix, glossary).

`` `cr.HP` `236HK` (+8) `` renders as: **HP/HK** red chips, **236**→↓↘→, **(+8)** blue.

## Changes

**1. Colored rendering (buttons + motions)**
- Tokens `--notation-light/medium/heavy` (blue/yellow/red by L/M/H).
- Pure parser `notation-parser.ts` (token → `button`/`motion`/`frame`/`text` segments) + `<NotationChip>`.
- Composed renderer `notationComponents = { ...frameDataComponents, code }` — colors notation **inside inline-code only** (no false positives in prose). Propagated to memo preview, cell editor and grid.
- Numpad motions → arrow glyphs (236→↓↘→, 623, 214…).

**2. "Auto-notation" insertion + Motion dropdown**
- Shared `<NotationToolbar>`: 3 dropdowns (Notation · **Motion** · Frames).
- Pure helper `insert-notation.ts`: auto-wraps tokens into inline-code, **no backtick typing required**. **Buttons** close the zone and add a space **outside** the backtick (`closeZone`).
- **Numpad** decision (stores `236`, rendered as arrows) — queryable by RAG/AI, accessible (tooltips).

**3. Glossary**
- `<NotationToolbar>` in the editor (`content-field.tsx`).
- Colored rendering in the admin preview (`markdown-preview.tsx`) and the public article view (`glossary-article-detail.tsx`), via reusable `renderInlineNotation` + `highlightFrameData`.

## Testing
- `pnpm ts` · `pnpm lint` (no warnings) · `pnpm test:run` — **19 notation tests** (parser + insertion).
- Verified in-browser (CDP): dropdown insertion + colored rendering on memo and glossary editor (L/M/H intensities, motion glyphs, frame data in prose, plain prose left uncolored).

## Out of scope (follow-ups)
Buttons/motions legend, inline `:` palette, text alignment (`remark-directive`).

No schema migration, no new dependency, no Tiptap.