### PR TITLE
feat(dashboard): add quick-access icon rail and dedupe navigation

### DIFF
--- a/.claude/rules/accessibility.md
+++ b/.claude/rules/accessibility.md
@@ -1,0 +1,31 @@
+# Accessibility (a11y)
+
+Every component and page must be usable with a keyboard and a screen reader. These rules are non-negotiable for new or edited UI.
+
+## Icon-only controls
+
+- Any control whose visible content is **only an icon** (buttons, links, toggles) MUST expose an accessible name via `aria-label` (or visually-hidden text). A tooltip is **supplementary**, never the only label.
+- Decorative icons MUST be `aria-hidden` (e.g. `<Icon aria-hidden />`) so the accessible name comes from the `aria-label`, not the SVG.
+
+## Landmarks & current state
+
+- Group navigation in a `<nav>` with a descriptive `aria-label` (e.g. `aria-label="Accès rapide au labo"`).
+- Mark the active destination with `aria-current="page"` so it is announced, not only colored.
+- Never rely on color alone to convey state — pair it with a shape, icon, text, or `aria-current`.
+
+## Focus
+
+- Keep a visible focus indicator. Use `focus-visible:ring-2 focus-visible:ring-ring` (semantic tokens) — never `outline-none` without a visible replacement.
+- Do not remove focus styles to "clean up" a design.
+
+## Target size
+
+- Interactive targets should be **at least 44×44px** (WCAG 2.5.5). Prefer `size-11` for icon buttons; pad smaller hit areas.
+
+## Motion
+
+- Respect `prefers-reduced-motion`. Avoid entrance/transform animations on persistent chrome (rails, sidebars, sticky bars). Keep transitions to color/opacity when motion is reduced.
+
+## Tokens
+
+- Accessible color contrast comes from the FGC semantic tokens (`text-foreground`, `text-muted-foreground`, `text-primary`, `bg-accent`). Do not hand-pick raw colors that break contrast — see `design-system.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## 2026-06-21
 
+### Added: Quick-access icon rail (Replays, Combos, Matrices, Mémos, Glossaire) as a right-edge overlay from the lg breakpoint, with accessible labels and tooltips
+
+### Changed: Deduplicate authenticated navigation — top bar keeps Dashboard/Stream/Admin, the rail owns the labo modules, and the mobile menu becomes the complete grouped menu
+
+### Docs: Add accessibility (a11y) rule for icon-only controls, focus, landmarks and target size
+
 ### Added: FGC notation toolbar in the glossary article editor, with colored rendering in the admin preview and the public article view
 
 ## 2026-06-20

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Footer } from "@/components/features/landing/footer";
 import { Header } from "@/components/features/landing/header";
+import { QuickRail } from "@/components/layout/quick-rail";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { websiteConfig } from "@/config/website-config";
@@ -47,6 +48,7 @@ export default function RootLayout({
             <main className="flex-1">{children}</main>
             <Footer />
           </div>
+          <QuickRail />
           <Toaster />
         </ThemeProvider>
       </body>

--- a/src/components/features/landing/authenticated-nav.tsx
+++ b/src/components/features/landing/authenticated-nav.tsx
@@ -36,8 +36,6 @@ export function AuthenticatedNav({ user }: AuthenticatedNavProps) {
     <>
       <div className="hidden items-center gap-4 lg:flex">
         <NavLink href="/dashboard">Dashboard</NavLink>
-        <NavLink href="/combos">Combos</NavLink>
-        <NavLink href="/glossary">Glossaire</NavLink>
         <NavLink href="/stream">Stream</NavLink>
         {user.role === "ADMIN" && (
           <DropdownMenu>
@@ -80,14 +78,25 @@ export function AuthenticatedNav({ user }: AuthenticatedNavProps) {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-56">
+            <DropdownMenuLabel>Labo</DropdownMenuLabel>
             <DropdownMenuItem asChild>
-              <Link href="/dashboard">Dashboard</Link>
+              <Link href="/videos">Replays</Link>
             </DropdownMenuItem>
             <DropdownMenuItem asChild>
               <Link href="/combos">Combos</Link>
             </DropdownMenuItem>
             <DropdownMenuItem asChild>
+              <Link href="/notes/strategy">Matrices</Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/notes/memo">Mémos</Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
               <Link href="/glossary">Glossaire</Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <Link href="/dashboard">Dashboard</Link>
             </DropdownMenuItem>
             <DropdownMenuItem asChild>
               <Link href="/stream">Stream</Link>

--- a/src/components/layout/quick-rail.tsx
+++ b/src/components/layout/quick-rail.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import {
+  BookOpen,
+  Clapperboard,
+  Grid3x3,
+  NotebookPen,
+  Swords,
+  type LucideIcon,
+} from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useSession } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
+
+type RailItem = {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+};
+
+const RAIL_ITEMS: RailItem[] = [
+  { href: "/videos", label: "Replays", icon: Clapperboard },
+  { href: "/combos", label: "Combos", icon: Swords },
+  { href: "/notes/strategy", label: "Matrices", icon: Grid3x3 },
+  { href: "/notes/memo", label: "Mémos", icon: NotebookPen },
+  { href: "/glossary", label: "Glossaire", icon: BookOpen },
+];
+
+export function QuickRail() {
+  const pathname = usePathname();
+  const { data: session, isPending } = useSession();
+
+  if (isPending || !session?.user || pathname === "/") {
+    return null;
+  }
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <nav
+        aria-label="Accès rapide au labo"
+        className="fixed top-1/2 right-6 z-40 hidden -translate-y-1/2 lg:block"
+      >
+        <ul className="border-border bg-card/80 supports-[backdrop-filter]:bg-card/60 flex flex-col items-center gap-1 rounded-2xl border p-1.5 shadow-lg backdrop-blur-md">
+          {RAIL_ITEMS.map((item) => {
+            const Icon = item.icon;
+            const isActive =
+              pathname === item.href || pathname.startsWith(`${item.href}/`);
+
+            return (
+              <li key={item.href}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Link
+                      href={item.href}
+                      aria-label={item.label}
+                      aria-current={isActive ? "page" : undefined}
+                      className={cn(
+                        "focus-visible:ring-ring relative flex size-11 items-center justify-center rounded-xl outline-none transition-colors focus-visible:ring-2",
+                        isActive
+                          ? "bg-accent text-primary"
+                          : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+                      )}
+                    >
+                      {isActive ? (
+                        <span
+                          aria-hidden
+                          className="bg-primary absolute top-1/2 -right-1.5 h-5 w-1 -translate-y-1/2 rounded-full"
+                        />
+                      ) : null}
+                      <Icon aria-hidden className="size-5" />
+                    </Link>
+                  </TooltipTrigger>
+                  <TooltipContent side="left" sideOffset={12}>
+                    {item.label}
+                  </TooltipContent>
+                </Tooltip>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
## Summary

A right-edge icon rail gives one-click access to the five "labo" modules (Replays, Combos, Matrices, Mémos, Glossaire) on every authenticated page. The navigation is deduplicated so each destination has a single home, with no dead-ends at any breakpoint.

## Changes

- **New `QuickRail`** — fixed overlay on the right, visible from the `lg` breakpoint. Icon-only links with `aria-label`, supplementary tooltips, `aria-current="page"` active state, and a brand-token accent indicator. Built on the existing FGC semantic tokens.
- Mounted globally; renders **only for authenticated users** and is hidden on the landing page.
- **Deduplicated `AuthenticatedNav`**: the top bar keeps the cross-cutting items (Dashboard, Stream, Admin); the rail owns the labo modules. The mobile hamburger becomes the complete grouped menu, adding the previously unreachable Replays / Matrices / Mémos.
- **New `.claude/rules/accessibility.md`** — codifies icon-only labels, visible focus, nav landmarks, 44px target size, and reduced-motion.

## Testing

- `pnpm lint` ✓
- `pnpm ts` ✓