### PR TITLE
refactor(test): extract shared renderWithIntl helper and add DRY rule

### DIFF
--- a/.claude/rules/dry.md
+++ b/.claude/rules/dry.md
@@ -1,0 +1,26 @@
+# DRY — Don't Repeat Yourself
+
+Before duplicating logic, markup or config, reuse the shared building blocks below. Extract a shared helper/component the **third** time a pattern appears (rule of three) — earlier if the duplication is error-prone.
+
+## Reuse these (don't re-inline)
+
+- **Dates**: `formatDate` / `formatTime` from `@/utils` — do not re-inline `toLocaleDateString("fr-FR", …)`.
+- **i18n test render**: `renderWithIntl` from `@/test/render-with-intl` — never redeclare the `NextIntlClientProvider` wrapper in a test file.
+- **Translations**: `getTranslations` / `useTranslations` + the `fr` catalogs (see `i18n.md`). Generic labels live in the `common` namespace — reuse, don't duplicate.
+- **Form validation display**: the shadcn `FormMessage` already translates Zod message keys — don't build per-form error rendering.
+- **Action feedback**: keep the next-safe-action `error.serverError ?? t(...)` toast pattern consistent.
+
+## Extract when you see it 3×
+
+- A confirmation dialog → a single `ConfirmDeleteDialog`, not an inline `AlertDialog` per list.
+- A near-identical section/card → one config-driven component.
+- A repeated Zod fragment (e.g. the slug rule) → a shared schema piece.
+
+## Known consolidation backlog (dedicated session)
+
+1. Admin CRUD triplication (game / character / article: form + list + action + schema, ~64% identical) → generic CRUD scaffold + shared `slugSchema` + a `makeEntityActions` factory.
+2. Inline delete `AlertDialog` repeated in ~7 lists → reuse a `ConfirmDeleteDialog`.
+3. Dashboard `recent-*-section.tsx` (×3, near-identical) → one `RecentSection`.
+4. next-safe-action toast boilerplate in ~16 files → a `useActionToast` hook.
+5. `(key: string) => string` translator type duplicated 3× (`MatchTranslator`, `TemplateTranslator`, `replay-card`) → one shared `Translator`.
+6. `formatDate` underused — ~7 inline `toLocaleDateString` call sites (mind the long `fr-FR` vs short format).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## 2026-06-21
 
+### Refactor: Extract a shared renderWithIntl test helper and point all i18n-aware tests at it (DRY)
+
+### Docs: Add DRY rule with shared building blocks and a consolidation backlog
+
 ### Fixed: Scope the homepage e2e "ComboTrack" link locator to the header (resolve strict-mode flake from the duplicate footer logo link)
 
 ### Added: Extract all hardcoded French UI strings into next-intl catalogs across every feature domain (landing, dashboard, admin, glossary, strategy-matrix, video, memo, combo, match, auth, nav, capture, stream, search)

--- a/src/components/features/auth/sign-up-form.test.tsx
+++ b/src/components/features/auth/sign-up-form.test.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from "@testing-library/react";
-import { NextIntlClientProvider } from "next-intl";
+import { screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { frMessages } from "@/i18n/messages";
+import { renderWithIntl } from "@/test/render-with-intl";
 
 // Mock upload avatar action
 vi.mock("@/lib/actions/upload-avatar", () => ({
@@ -13,11 +12,7 @@ import { SignUpForm } from "./sign-up-form";
 
 describe("SignUpForm", () => {
   it("should render the form", () => {
-    render(
-      <NextIntlClientProvider locale="fr" messages={frMessages}>
-        <SignUpForm />
-      </NextIntlClientProvider>,
-    );
+    renderWithIntl(<SignUpForm />);
     expect(screen.getByText("Créer un compte")).toBeInTheDocument();
   });
 });

--- a/src/components/features/landing/nav-link.test.tsx
+++ b/src/components/features/landing/nav-link.test.tsx
@@ -1,19 +1,9 @@
-import { render, screen } from "@testing-library/react";
-import { NextIntlClientProvider } from "next-intl";
-import { type ReactNode } from "react";
+import { screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { usePathname } from "next/navigation";
 
-import { frMessages } from "@/i18n/messages";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { NavLink } from "./nav-link";
-
-function renderWithIntl(ui: ReactNode) {
-  return render(
-    <NextIntlClientProvider locale="fr" messages={frMessages}>
-      {ui}
-    </NextIntlClientProvider>,
-  );
-}
 
 describe("NavLink", () => {
   it("should render a link with the button text", () => {

--- a/src/components/features/search/search-command-dialog.test.tsx
+++ b/src/components/features/search/search-command-dialog.test.tsx
@@ -1,10 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { NextIntlClientProvider } from "next-intl";
-import { type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { frMessages } from "@/i18n/messages";
+import { renderWithIntl } from "@/test/render-with-intl";
 
 vi.mock("next-safe-action/hooks", () => ({
   useAction: () => ({
@@ -21,14 +19,6 @@ vi.mock("./semantic-search-action", () => ({
 import { useSearchDialogStore } from "@/stores/search-dialog";
 import { SearchCommandDialog } from "./search-command-dialog";
 import { SearchTriggerButton } from "./search-trigger-button";
-
-function renderWithIntl(ui: ReactNode) {
-  return render(
-    <NextIntlClientProvider locale="fr" messages={frMessages}>
-      {ui}
-    </NextIntlClientProvider>,
-  );
-}
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/src/components/features/search/semantic-search-bar.test.tsx
+++ b/src/components/features/search/semantic-search-bar.test.tsx
@@ -1,15 +1,7 @@
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
-import { NextIntlClientProvider } from "next-intl";
-import { type ReactNode } from "react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { frMessages } from "@/i18n/messages";
+import { renderWithIntl } from "@/test/render-with-intl";
 
 const executeMock = vi.fn();
 const useActionMock = vi.fn(() => ({
@@ -27,14 +19,6 @@ vi.mock("./semantic-search-action", () => ({
 }));
 
 import { SemanticSearchBar } from "./semantic-search-bar";
-
-function renderWithIntl(ui: ReactNode) {
-  return render(
-    <NextIntlClientProvider locale="fr" messages={frMessages}>
-      {ui}
-    </NextIntlClientProvider>,
-  );
-}
 
 beforeEach(() => {
   executeMock.mockClear();

--- a/src/components/features/search/semantic-search-results.test.tsx
+++ b/src/components/features/search/semantic-search-results.test.tsx
@@ -1,18 +1,8 @@
-import { render, screen } from "@testing-library/react";
-import { NextIntlClientProvider } from "next-intl";
-import { type ReactNode } from "react";
+import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { frMessages } from "@/i18n/messages";
+import { renderWithIntl } from "@/test/render-with-intl";
 import { SemanticSearchResults } from "./semantic-search-results";
-
-function renderWithIntl(ui: ReactNode) {
-  return render(
-    <NextIntlClientProvider locale="fr" messages={frMessages}>
-      {ui}
-    </NextIntlClientProvider>,
-  );
-}
 
 describe("SemanticSearchResults", () => {
   it("prompts when query too short", () => {

--- a/src/test/render-with-intl.tsx
+++ b/src/test/render-with-intl.tsx
@@ -1,0 +1,13 @@
+import { render } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { type ReactNode } from "react";
+
+import { frMessages } from "@/i18n/messages";
+
+export function renderWithIntl(ui: ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="fr" messages={frMessages}>
+      {ui}
+    </NextIntlClientProvider>,
+  );
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -25,6 +25,7 @@ export default defineConfig({
         ".next/",
         "coverage/",
         "__mocks__/",
+        "src/test/**",
       ],
       thresholds: {
         lines: 80,


### PR DESCRIPTION
## Summary

Apply DRY to the i18n-aware test setup and codify the principle as a project rule.

## Changes

- Add `src/test/render-with-intl.tsx` — a shared `renderWithIntl(ui)` wrapping `NextIntlClientProvider` with the `fr` messages.
- Point `nav-link`, `sign-up-form` and the three `search` tests at it (remove the per-file redeclarations and now-unused imports).
- Exclude `src/test/**` from coverage.
- Add `.claude/rules/dry.md` — shared building blocks to reuse (dates, i18n test render, validation display, action toasts) and a consolidation backlog for a dedicated session.

> The unwired quick-capture WIP tests are intentionally left untouched.

## Testing

- `pnpm exec vitest run` (5 affected files) — 18 tests ✓
- `pnpm ts` ✓ · `pnpm lint` ✓
