### PR TITLE
refactor(dry): consolidate duplicated components and utilities

### DIFF
--- a/.claude/rules/dry.md
+++ b/.claude/rules/dry.md
@@ -4,23 +4,28 @@ Before duplicating logic, markup or config, reuse the shared building blocks bel
 
 ## Reuse these (don't re-inline)
 
-- **Dates**: `formatDate` / `formatTime` from `@/utils` — do not re-inline `toLocaleDateString("fr-FR", …)`.
+- **Dates**: `formatDate` (short), `formatDateLong` (long month), `formatDateFull` (weekday) and `formatTime` from `@/utils` — do not re-inline `toLocaleDateString("fr-FR", …)`.
+- **Action feedback**: `useActionToast` from `@/hooks/use-action-toast` — wraps `useAction` with the `toast.success` / `toast.error(error.serverError ?? …)` boilerplate. Pass already-translated `successMessage` / `errorMessage`; keep side effects in `onSuccess` / `onError`.
+- **Delete confirmation**: `ConfirmDeleteDialog` from `@/components/shared/confirm-delete-dialog` (+ `useDeleteDialog` from `@/hooks/use-delete-dialog`) — never inline an `AlertDialog` delete flow per list.
+- **Dashboard sections**: `RecentSection` from `@/components/features/dashboard/recent-section` — generic header + empty state + animated grid/list.
+- **Admin form footer**: `EntityFormButtons` from `@/components/features/admin/shared/entity-form-buttons` — shared cancel/submit block.
+- **Admin Zod fragments**: `slugSchema` / `nameSchema` / `urlFieldSchema` / `withIdExtension` / `SLUG_REGEX` from `@/lib/validations/admin-schemas`.
+- **Translator type**: `Translator` from `@/types/translator` — never re-declare `(key: string) => string`.
 - **i18n test render**: `renderWithIntl` from `@/test/render-with-intl` — never redeclare the `NextIntlClientProvider` wrapper in a test file.
 - **Translations**: `getTranslations` / `useTranslations` + the `fr` catalogs (see `i18n.md`). Generic labels live in the `common` namespace — reuse, don't duplicate.
 - **Form validation display**: the shadcn `FormMessage` already translates Zod message keys — don't build per-form error rendering.
-- **Action feedback**: keep the next-safe-action `error.serverError ?? t(...)` toast pattern consistent.
 
 ## Extract when you see it 3×
 
-- A confirmation dialog → a single `ConfirmDeleteDialog`, not an inline `AlertDialog` per list.
-- A near-identical section/card → one config-driven component.
-- A repeated Zod fragment (e.g. the slug rule) → a shared schema piece.
+- A confirmation dialog → reuse `ConfirmDeleteDialog`, not an inline `AlertDialog` per list.
+- A near-identical section/card → one config-driven component (see `RecentSection`).
+- A repeated Zod fragment (e.g. the slug rule) → a shared schema piece in `admin-schemas.ts`.
 
-## Known consolidation backlog (dedicated session)
+## Known consolidation backlog
 
-1. Admin CRUD triplication (game / character / article: form + list + action + schema, ~64% identical) → generic CRUD scaffold + shared `slugSchema` + a `makeEntityActions` factory.
-2. Inline delete `AlertDialog` repeated in ~7 lists → reuse a `ConfirmDeleteDialog`.
-3. Dashboard `recent-*-section.tsx` (×3, near-identical) → one `RecentSection`.
-4. next-safe-action toast boilerplate in ~16 files → a `useActionToast` hook.
-5. `(key: string) => string` translator type duplicated 3× (`MatchTranslator`, `TemplateTranslator`, `replay-card`) → one shared `Translator`.
-6. `formatDate` underused — ~7 inline `toLocaleDateString` call sites (mind the long `fr-FR` vs short format).
+Resolved (2026-06-21): inline delete dialog (`ConfirmDeleteDialog` + `useDeleteDialog`), dashboard `recent-*` (`RecentSection`), toast boilerplate (`useActionToast`, 16 sites), `Translator` type, `formatDate` underuse, shared admin Zod fragments + `EntityFormButtons`.
+
+Remaining (gated — dedicated PR):
+
+1. **Admin CRUD action factory** — game / character / action create+update+delete actions are still ~67% identical. A `makeEntityActions({ model, schemas, revalidatePaths, slugScope, getCreateData, getUpdateData, onCreateHook?, onUpdateHook? })` factory would collapse them. Deferred because the generic Prisma-model typing is delicate and must not break the article RAG `after()`/`embedGlossaryArticleIfNeeded` hook — design before coding.
+2. Two delete dialogs still use the per-card `AlertDialogTrigger` idiom (`strategy-matrix-list`, `memo-list`); migrate to `ConfirmDeleteDialog` only if a controlled-state refactor of those loops is worthwhile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-06-22
+
+### Refactor: Add a shared Translator type and replace the duplicated MatchTranslator/TemplateTranslator/inline casts (DRY)
+
+### Refactor: Add formatDateLong/formatDateFull utils and route ~9 inline toLocaleDateString call sites through @/utils (DRY)
+
+### Fixed: Reuse @/lib/slug generateSlug in the article form instead of a duplicated local implementation
+
+### Refactor: Extract shared admin Zod building blocks (slugSchema/nameSchema/urlFieldSchema/withIdExtension + SLUG_REGEX) for game/character/article schemas (DRY)
+
+### Refactor: Extract a shared ConfirmDeleteDialog + useDeleteDialog hook and reuse them across admin, note, combo lists (DRY)
+
+### Refactor: Extract a generic RecentSection component and thin the three dashboard recent-* sections down to config (DRY)
+
+### Refactor: Extract a useActionToast hook and migrate the 16 next-safe-action toast call sites onto it (DRY)
+
+### Refactor: Extract a shared EntityFormButtons footer for the admin game/character/article forms (DRY)
+
 ## 2026-06-21
 
 ### Refactor: Extract a shared renderWithIntl test helper and point all i18n-aware tests at it (DRY)

--- a/app/(dashboard)/notes/memo/[id]/page.tsx
+++ b/app/(dashboard)/notes/memo/[id]/page.tsx
@@ -2,6 +2,7 @@ import { MemoForm } from "@/components/features/memo/memo-form";
 import { requireAuth } from "@/lib/auth-utils";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import { formatDateLong } from "@/utils";
 import { getMemoById } from "../../../../../prisma/query/memo.query";
 
 export default async function MemoDetailPage({
@@ -27,12 +28,7 @@ export default async function MemoDetailPage({
           {t("pages.editTitle")}
         </h1>
         <p className="text-muted-foreground mt-1">
-          {t("list.updatedOn")}{" "}
-          {new Date(memo.updatedAt).toLocaleDateString("fr-FR", {
-            day: "2-digit",
-            month: "long",
-            year: "numeric",
-          })}
+          {t("list.updatedOn")} {formatDateLong(memo.updatedAt)}
         </p>
       </div>
 

--- a/src/components/features/admin/character/character-form.tsx
+++ b/src/components/features/admin/character/character-form.tsx
@@ -2,10 +2,8 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { useAction } from "next-safe-action/hooks";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { toast } from "sonner";
 
 import {
   Form,
@@ -17,7 +15,6 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -37,6 +34,8 @@ import {
 import { AdminCharacterDetail } from "@/../prisma/query/admin-character.query";
 import { GameOption } from "@/../prisma/query/game.query";
 import { generateSlug } from "@/lib/slug";
+import { useActionToast } from "@/hooks/use-action-toast";
+import { EntityFormButtons } from "@/components/features/admin/shared/entity-form-buttons";
 
 interface CharacterFormProps {
   mode: "create" | "edit";
@@ -49,30 +48,26 @@ export function CharacterForm({ mode, character, games }: CharacterFormProps) {
   const t = useTranslations("admin");
   const tCommon = useTranslations("common");
 
-  const { execute: createExecute, isPending: isCreating } = useAction(
+  const { execute: createExecute, isPending: isCreating } = useActionToast(
     createCharacterAction,
     {
+      successMessage: t("character.toast.created"),
+      errorMessage: t("character.toast.createError"),
       onSuccess: () => {
-        toast.success(t("character.toast.created"));
         router.push("/admin/characters");
         router.refresh();
-      },
-      onError: ({ error }) => {
-        toast.error(error.serverError ?? t("character.toast.createError"));
       },
     },
   );
 
-  const { execute: updateExecute, isPending: isUpdating } = useAction(
+  const { execute: updateExecute, isPending: isUpdating } = useActionToast(
     updateCharacterAction,
     {
+      successMessage: t("character.toast.updated"),
+      errorMessage: t("character.toast.updateError"),
       onSuccess: () => {
-        toast.success(t("character.toast.updated"));
         router.push("/admin/characters");
         router.refresh();
-      },
-      onError: ({ error }) => {
-        toast.error(error.serverError ?? t("character.toast.updateError"));
       },
     },
   );
@@ -198,25 +193,16 @@ export function CharacterForm({ mode, character, games }: CharacterFormProps) {
           )}
         />
 
-        <div className="flex gap-4">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => router.push("/admin/characters")}
-            disabled={isPending}
-          >
-            {tCommon("buttons.cancel")}
-          </Button>
-          <Button type="submit" disabled={isPending}>
-            {isPending
-              ? mode === "create"
-                ? t("character.form.creating")
-                : t("character.form.updating")
-              : mode === "create"
-                ? t("character.form.createSubmit")
-                : t("character.form.updateSubmit")}
-          </Button>
-        </div>
+        <EntityFormButtons
+          mode={mode}
+          isPending={isPending}
+          onCancel={() => router.push("/admin/characters")}
+          cancelLabel={tCommon("buttons.cancel")}
+          createLabel={t("character.form.createSubmit")}
+          updateLabel={t("character.form.updateSubmit")}
+          creatingLabel={t("character.form.creating")}
+          updatingLabel={t("character.form.updating")}
+        />
       </form>
     </Form>
   );

--- a/src/components/features/admin/character/character-list.tsx
+++ b/src/components/features/admin/character/character-list.tsx
@@ -1,23 +1,10 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { useAction } from "next-safe-action/hooks";
 import { useTranslations } from "next-intl";
-import { toast } from "sonner";
 import { Edit, Trash2, MoreVertical } from "lucide-react";
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -26,6 +13,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ConfirmDeleteDialog } from "@/components/shared/confirm-delete-dialog";
+import { useActionToast } from "@/hooks/use-action-toast";
+import { useDeleteDialog } from "@/hooks/use-delete-dialog";
 
 import { deleteCharacterAction } from "./character-action";
 import { AdminCharacterList } from "@/../prisma/query/admin-character.query";
@@ -38,32 +28,20 @@ export function CharacterList({ characters }: CharacterListProps) {
   const router = useRouter();
   const t = useTranslations("admin");
   const tCommon = useTranslations("common");
-  const [deleteDialog, setDeleteDialog] = useState<{
-    open: boolean;
-    character: AdminCharacterList[number] | null;
-  }>({
-    open: false,
-    character: null,
-  });
+  const deleteDialog = useDeleteDialog<AdminCharacterList[number]>();
 
-  const { execute, isPending } = useAction(deleteCharacterAction, {
+  const { execute, isPending } = useActionToast(deleteCharacterAction, {
+    successMessage: t("character.toast.deleted"),
+    errorMessage: t("character.toast.deleteError"),
     onSuccess: () => {
-      toast.success(t("character.toast.deleted"));
-      setDeleteDialog({ open: false, character: null });
+      deleteDialog.close();
       router.refresh();
     },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("character.toast.deleteError"));
-    },
   });
 
-  const openDeleteDialog = (character: AdminCharacterList[number]) => {
-    setDeleteDialog({ open: true, character });
-  };
-
   const handleDelete = () => {
-    if (deleteDialog.character) {
-      execute({ id: deleteDialog.character.id });
+    if (deleteDialog.item) {
+      execute({ id: deleteDialog.item.id });
     }
   };
 
@@ -125,7 +103,7 @@ export function CharacterList({ characters }: CharacterListProps) {
                             </Link>
                           </DropdownMenuItem>
                           <DropdownMenuItem
-                            onClick={() => openDeleteDialog(character)}
+                            onClick={() => deleteDialog.openWith(character)}
                             className="text-destructive"
                           >
                             <Trash2 className="mr-2 h-4 w-4" />
@@ -156,38 +134,18 @@ export function CharacterList({ characters }: CharacterListProps) {
         ))}
       </div>
 
-      <AlertDialog
+      <ConfirmDeleteDialog
         open={deleteDialog.open}
-        onOpenChange={(open) =>
-          !open && setDeleteDialog({ open: false, character: null })
-        }
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t("character.deleteDialog.title")}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {deleteDialog.character?.name}
-              <br />
-              <br />
-              {t("character.deleteDialog.description")}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {tCommon("buttons.cancel")}
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              disabled={isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {isPending ? t("actions.deleting") : tCommon("buttons.delete")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onOpenChange={deleteDialog.onOpenChange}
+        title={t("character.deleteDialog.title")}
+        description={t("character.deleteDialog.description")}
+        itemName={deleteDialog.item?.name}
+        isPending={isPending}
+        onConfirm={handleDelete}
+        confirmLabel={tCommon("buttons.delete")}
+        cancelLabel={tCommon("buttons.cancel")}
+        deletingLabel={t("actions.deleting")}
+      />
     </>
   );
 }

--- a/src/components/features/admin/character/character-schema.ts
+++ b/src/components/features/admin/character/character-schema.ts
@@ -1,27 +1,23 @@
 import z from "zod";
 
+import {
+  nameSchema,
+  slugSchema,
+  urlFieldSchema,
+  withIdExtension,
+} from "@/lib/validations/admin-schemas";
+
+const base = "admin.validation.character";
+
 export const characterFormSchema = z.object({
-  gameId: z.string().min(1, "admin.validation.character.gameRequired"),
-  name: z
-    .string()
-    .min(2, "admin.validation.character.nameMin")
-    .max(60, "admin.validation.character.nameMax"),
-  slug: z
-    .string()
-    .min(1, "admin.validation.character.slugRequired")
-    .max(40, "admin.validation.character.slugMax")
-    .regex(/^[a-z0-9-]+$/, "admin.validation.character.slugFormat"),
-  iconUrl: z
-    .string()
-    .url("admin.validation.character.iconUrlInvalid")
-    .optional()
-    .or(z.literal("")),
+  gameId: z.string().min(1, `${base}.gameRequired`),
+  name: nameSchema({ base, min: 2, max: 60 }),
+  slug: slugSchema({ base, min: 1, max: 40, minKey: "slugRequired" }),
+  iconUrl: urlFieldSchema(`${base}.iconUrlInvalid`),
 });
 
 export type CharacterFormSchemaType = z.infer<typeof characterFormSchema>;
 
 export const createCharacterSchema = characterFormSchema;
 
-export const updateCharacterSchema = characterFormSchema.extend({
-  id: z.string().min(1),
-});
+export const updateCharacterSchema = withIdExtension(characterFormSchema);

--- a/src/components/features/admin/game/game-form.tsx
+++ b/src/components/features/admin/game/game-form.tsx
@@ -2,10 +2,8 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { useAction } from "next-safe-action/hooks";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { toast } from "sonner";
 
 import {
   Form,
@@ -17,12 +15,13 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
 
 import { gameFormSchema, GameFormSchemaType } from "./game-schema";
 import { createGameAction, updateGameAction } from "./game-action";
 import { AdminGameDetail } from "@/../prisma/query/admin-game.query";
 import { generateSlug } from "@/lib/slug";
+import { useActionToast } from "@/hooks/use-action-toast";
+import { EntityFormButtons } from "@/components/features/admin/shared/entity-form-buttons";
 
 interface GameFormProps {
   mode: "create" | "edit";
@@ -34,30 +33,26 @@ export function GameForm({ mode, game }: GameFormProps) {
   const t = useTranslations("admin");
   const tCommon = useTranslations("common");
 
-  const { execute: createExecute, isPending: isCreating } = useAction(
+  const { execute: createExecute, isPending: isCreating } = useActionToast(
     createGameAction,
     {
+      successMessage: t("game.toast.created"),
+      errorMessage: t("game.toast.createError"),
       onSuccess: () => {
-        toast.success(t("game.toast.created"));
         router.push("/admin/games");
         router.refresh();
-      },
-      onError: ({ error }) => {
-        toast.error(error.serverError ?? t("game.toast.createError"));
       },
     },
   );
 
-  const { execute: updateExecute, isPending: isUpdating } = useAction(
+  const { execute: updateExecute, isPending: isUpdating } = useActionToast(
     updateGameAction,
     {
+      successMessage: t("game.toast.updated"),
+      errorMessage: t("game.toast.updateError"),
       onSuccess: () => {
-        toast.success(t("game.toast.updated"));
         router.push("/admin/games");
         router.refresh();
-      },
-      onError: ({ error }) => {
-        toast.error(error.serverError ?? t("game.toast.updateError"));
       },
     },
   );
@@ -146,25 +141,16 @@ export function GameForm({ mode, game }: GameFormProps) {
           )}
         />
 
-        <div className="flex gap-4">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => router.push("/admin/games")}
-            disabled={isPending}
-          >
-            {tCommon("buttons.cancel")}
-          </Button>
-          <Button type="submit" disabled={isPending}>
-            {isPending
-              ? mode === "create"
-                ? t("game.form.creating")
-                : t("game.form.updating")
-              : mode === "create"
-                ? t("game.form.createSubmit")
-                : t("game.form.updateSubmit")}
-          </Button>
-        </div>
+        <EntityFormButtons
+          mode={mode}
+          isPending={isPending}
+          onCancel={() => router.push("/admin/games")}
+          cancelLabel={tCommon("buttons.cancel")}
+          createLabel={t("game.form.createSubmit")}
+          updateLabel={t("game.form.updateSubmit")}
+          creatingLabel={t("game.form.creating")}
+          updatingLabel={t("game.form.updating")}
+        />
       </form>
     </Form>
   );

--- a/src/components/features/admin/game/game-list.tsx
+++ b/src/components/features/admin/game/game-list.tsx
@@ -1,23 +1,10 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { useAction } from "next-safe-action/hooks";
 import { useTranslations } from "next-intl";
-import { toast } from "sonner";
 import { Edit, Trash2, MoreVertical } from "lucide-react";
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -26,6 +13,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ConfirmDeleteDialog } from "@/components/shared/confirm-delete-dialog";
+import { useActionToast } from "@/hooks/use-action-toast";
+import { useDeleteDialog } from "@/hooks/use-delete-dialog";
+import { formatDate } from "@/utils";
 
 import { deleteGameAction } from "./game-action";
 import { AdminGameList } from "@/../prisma/query/admin-game.query";
@@ -38,32 +29,20 @@ export function GameList({ games }: GameListProps) {
   const router = useRouter();
   const t = useTranslations("admin");
   const tCommon = useTranslations("common");
-  const [deleteDialog, setDeleteDialog] = useState<{
-    open: boolean;
-    game: AdminGameList[number] | null;
-  }>({
-    open: false,
-    game: null,
-  });
+  const deleteDialog = useDeleteDialog<AdminGameList[number]>();
 
-  const { execute, isPending } = useAction(deleteGameAction, {
+  const { execute, isPending } = useActionToast(deleteGameAction, {
+    successMessage: t("game.toast.deleted"),
+    errorMessage: t("game.toast.deleteError"),
     onSuccess: () => {
-      toast.success(t("game.toast.deleted"));
-      setDeleteDialog({ open: false, game: null });
+      deleteDialog.close();
       router.refresh();
     },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("game.toast.deleteError"));
-    },
   });
 
-  const openDeleteDialog = (game: AdminGameList[number]) => {
-    setDeleteDialog({ open: true, game });
-  };
-
   const handleDelete = () => {
-    if (deleteDialog.game) {
-      execute({ id: deleteDialog.game.id });
+    if (deleteDialog.item) {
+      execute({ id: deleteDialog.item.id });
     }
   };
 
@@ -106,7 +85,7 @@ export function GameList({ games }: GameListProps) {
                       </Link>
                     </DropdownMenuItem>
                     <DropdownMenuItem
-                      onClick={() => openDeleteDialog(game)}
+                      onClick={() => deleteDialog.openWith(game)}
                       className="text-destructive"
                     >
                       <Trash2 className="mr-2 h-4 w-4" />
@@ -128,7 +107,7 @@ export function GameList({ games }: GameListProps) {
                 </span>
                 <span>
                   {t("game.list.updatedAt", {
-                    date: new Date(game.updatedAt).toLocaleDateString(),
+                    date: formatDate(game.updatedAt),
                   })}
                 </span>
               </div>
@@ -137,36 +116,18 @@ export function GameList({ games }: GameListProps) {
         ))}
       </div>
 
-      <AlertDialog
+      <ConfirmDeleteDialog
         open={deleteDialog.open}
-        onOpenChange={(open) =>
-          !open && setDeleteDialog({ open: false, game: null })
-        }
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t("game.deleteDialog.title")}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {deleteDialog.game?.name}
-              <br />
-              <br />
-              {t("game.deleteDialog.description")}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {tCommon("buttons.cancel")}
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              disabled={isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {isPending ? t("actions.deleting") : tCommon("buttons.delete")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onOpenChange={deleteDialog.onOpenChange}
+        title={t("game.deleteDialog.title")}
+        description={t("game.deleteDialog.description")}
+        itemName={deleteDialog.item?.name}
+        isPending={isPending}
+        onConfirm={handleDelete}
+        confirmLabel={tCommon("buttons.delete")}
+        cancelLabel={tCommon("buttons.cancel")}
+        deletingLabel={t("actions.deleting")}
+      />
     </>
   );
 }

--- a/src/components/features/admin/game/game-schema.ts
+++ b/src/components/features/admin/game/game-schema.ts
@@ -1,26 +1,22 @@
 import z from "zod";
 
+import {
+  nameSchema,
+  slugSchema,
+  urlFieldSchema,
+  withIdExtension,
+} from "@/lib/validations/admin-schemas";
+
+const base = "admin.validation.game";
+
 export const gameFormSchema = z.object({
-  name: z
-    .string()
-    .min(2, "admin.validation.game.nameMin")
-    .max(80, "admin.validation.game.nameMax"),
-  slug: z
-    .string()
-    .min(2, "admin.validation.game.slugMin")
-    .max(40, "admin.validation.game.slugMax")
-    .regex(/^[a-z0-9-]+$/, "admin.validation.game.slugFormat"),
-  iconUrl: z
-    .string()
-    .url("admin.validation.game.iconUrlInvalid")
-    .optional()
-    .or(z.literal("")),
+  name: nameSchema({ base, min: 2, max: 80 }),
+  slug: slugSchema({ base, min: 2, max: 40 }),
+  iconUrl: urlFieldSchema(`${base}.iconUrlInvalid`),
 });
 
 export type GameFormSchemaType = z.infer<typeof gameFormSchema>;
 
 export const createGameSchema = gameFormSchema;
 
-export const updateGameSchema = gameFormSchema.extend({
-  id: z.string().min(1),
-});
+export const updateGameSchema = withIdExtension(gameFormSchema);

--- a/src/components/features/admin/glossary/article-form.tsx
+++ b/src/components/features/admin/glossary/article-form.tsx
@@ -2,10 +2,8 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { useAction } from "next-safe-action/hooks";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { toast } from "sonner";
 
 import {
   Form,
@@ -19,7 +17,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
-import { Button } from "@/components/ui/button";
 
 import { articleFormSchema, ArticleFormSchemaType } from "./article-schema";
 import { createArticleAction, updateArticleAction } from "./article-action";
@@ -27,21 +24,13 @@ import { MarkdownPreview } from "./markdown-preview";
 import { ImageField } from "./image-field";
 import { ContentField } from "./content-field";
 import { AdminArticleDetail } from "@/../prisma/query/admin-glossary.query";
+import { generateSlug } from "@/lib/slug";
+import { useActionToast } from "@/hooks/use-action-toast";
+import { EntityFormButtons } from "@/components/features/admin/shared/entity-form-buttons";
 
 interface ArticleFormProps {
   mode: "create" | "edit";
   article?: NonNullable<AdminArticleDetail>;
-}
-
-function generateSlug(title: string): string {
-  return title
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/[^a-z0-9\s-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .trim();
 }
 
 export function ArticleForm({ mode, article }: ArticleFormProps) {
@@ -49,30 +38,26 @@ export function ArticleForm({ mode, article }: ArticleFormProps) {
   const t = useTranslations("admin");
   const tCommon = useTranslations("common");
 
-  const { execute: createExecute, isPending: isCreating } = useAction(
+  const { execute: createExecute, isPending: isCreating } = useActionToast(
     createArticleAction,
     {
+      successMessage: t("article.toast.created"),
+      errorMessage: t("article.toast.createError"),
       onSuccess: () => {
-        toast.success(t("article.toast.created"));
         router.push("/admin/glossary");
         router.refresh();
-      },
-      onError: ({ error }) => {
-        toast.error(error.serverError ?? t("article.toast.createError"));
       },
     },
   );
 
-  const { execute: updateExecute, isPending: isUpdating } = useAction(
+  const { execute: updateExecute, isPending: isUpdating } = useActionToast(
     updateArticleAction,
     {
+      successMessage: t("article.toast.updated"),
+      errorMessage: t("article.toast.updateError"),
       onSuccess: () => {
-        toast.success(t("article.toast.updated"));
         router.push("/admin/glossary");
         router.refresh();
-      },
-      onError: ({ error }) => {
-        toast.error(error.serverError ?? t("article.toast.updateError"));
       },
     },
   );
@@ -270,25 +255,16 @@ export function ArticleForm({ mode, article }: ArticleFormProps) {
           </div>
         </div>
 
-        <div className="flex gap-4">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => router.push("/admin/glossary")}
-            disabled={isPending}
-          >
-            {tCommon("buttons.cancel")}
-          </Button>
-          <Button type="submit" disabled={isPending}>
-            {isPending
-              ? mode === "create"
-                ? t("article.form.creating")
-                : t("article.form.updating")
-              : mode === "create"
-                ? t("article.form.createSubmit")
-                : t("article.form.updateSubmit")}
-          </Button>
-        </div>
+        <EntityFormButtons
+          mode={mode}
+          isPending={isPending}
+          onCancel={() => router.push("/admin/glossary")}
+          cancelLabel={tCommon("buttons.cancel")}
+          createLabel={t("article.form.createSubmit")}
+          updateLabel={t("article.form.updateSubmit")}
+          creatingLabel={t("article.form.creating")}
+          updatingLabel={t("article.form.updating")}
+        />
       </form>
     </Form>
   );

--- a/src/components/features/admin/glossary/article-list.tsx
+++ b/src/components/features/admin/glossary/article-list.tsx
@@ -1,23 +1,10 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { useAction } from "next-safe-action/hooks";
 import { useTranslations } from "next-intl";
-import { toast } from "sonner";
 import { Edit, Trash2, MoreVertical } from "lucide-react";
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -26,6 +13,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ConfirmDeleteDialog } from "@/components/shared/confirm-delete-dialog";
+import { useActionToast } from "@/hooks/use-action-toast";
+import { useDeleteDialog } from "@/hooks/use-delete-dialog";
+import { formatDate } from "@/utils";
 
 import { deleteArticleAction } from "./article-action";
 import { StatusBadge } from "./status-badge";
@@ -39,32 +30,20 @@ export function ArticleList({ articles }: ArticleListProps) {
   const router = useRouter();
   const t = useTranslations("admin");
   const tCommon = useTranslations("common");
-  const [deleteDialog, setDeleteDialog] = useState<{
-    open: boolean;
-    article: AdminArticleList[number] | null;
-  }>({
-    open: false,
-    article: null,
-  });
+  const deleteDialog = useDeleteDialog<AdminArticleList[number]>();
 
-  const { execute, isPending } = useAction(deleteArticleAction, {
+  const { execute, isPending } = useActionToast(deleteArticleAction, {
+    successMessage: t("article.toast.deleted"),
+    errorMessage: t("article.toast.deleteError"),
     onSuccess: () => {
-      toast.success(t("article.toast.deleted"));
-      setDeleteDialog({ open: false, article: null });
+      deleteDialog.close();
       router.refresh();
     },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("article.toast.deleteError"));
-    },
   });
 
-  const openDeleteDialog = (article: AdminArticleList[number]) => {
-    setDeleteDialog({ open: true, article });
-  };
-
   const handleDelete = () => {
-    if (deleteDialog.article) {
-      execute({ id: deleteDialog.article.id });
+    if (deleteDialog.item) {
+      execute({ id: deleteDialog.item.id });
     }
   };
 
@@ -114,7 +93,7 @@ export function ArticleList({ articles }: ArticleListProps) {
                       </Link>
                     </DropdownMenuItem>
                     <DropdownMenuItem
-                      onClick={() => openDeleteDialog(article)}
+                      onClick={() => deleteDialog.openWith(article)}
                       className="text-destructive"
                     >
                       <Trash2 className="mr-2 h-4 w-4" />
@@ -142,7 +121,7 @@ export function ArticleList({ articles }: ArticleListProps) {
                   </span>
                   <span>
                     {t("article.list.updatedAt", {
-                      date: new Date(article.updatedAt).toLocaleDateString(),
+                      date: formatDate(article.updatedAt),
                     })}
                   </span>
                 </div>
@@ -152,38 +131,18 @@ export function ArticleList({ articles }: ArticleListProps) {
         ))}
       </div>
 
-      <AlertDialog
+      <ConfirmDeleteDialog
         open={deleteDialog.open}
-        onOpenChange={(open) =>
-          !open && setDeleteDialog({ open: false, article: null })
-        }
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t("article.deleteDialog.title")}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {deleteDialog.article?.title}
-              <br />
-              <br />
-              {t("article.deleteDialog.description")}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {tCommon("buttons.cancel")}
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              disabled={isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {isPending ? t("actions.deleting") : tCommon("buttons.delete")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onOpenChange={deleteDialog.onOpenChange}
+        title={t("article.deleteDialog.title")}
+        description={t("article.deleteDialog.description")}
+        itemName={deleteDialog.item?.title}
+        isPending={isPending}
+        onConfirm={handleDelete}
+        confirmLabel={tCommon("buttons.delete")}
+        cancelLabel={tCommon("buttons.cancel")}
+        deletingLabel={t("actions.deleting")}
+      />
     </>
   );
 }

--- a/src/components/features/admin/glossary/article-schema.ts
+++ b/src/components/features/admin/glossary/article-schema.ts
@@ -1,27 +1,25 @@
 import z from "zod";
 
+import {
+  nameSchema,
+  slugSchema,
+  urlFieldSchema,
+  withIdExtension,
+} from "@/lib/validations/admin-schemas";
+
+const base = "admin.validation.article";
+
 export const articleFormSchema = z.object({
-  title: z
-    .string()
-    .min(3, "admin.validation.article.titleMin")
-    .max(200, "admin.validation.article.titleMax"),
-  slug: z
-    .string()
-    .min(3, "admin.validation.article.slugMin")
-    .max(200, "admin.validation.article.slugMax")
-    .regex(/^[a-z0-9-]+$/, "admin.validation.article.slugFormat"),
-  content: z.string().min(10, "admin.validation.article.contentMin"),
+  title: nameSchema({ base, min: 3, max: 200, field: "title" }),
+  slug: slugSchema({ base, min: 3, max: 200 }),
+  content: z.string().min(10, `${base}.contentMin`),
   excerpt: z
     .string()
-    .max(500, "admin.validation.article.excerptMax")
+    .max(500, `${base}.excerptMax`)
     .optional()
     .or(z.literal("")),
-  category: z.string().min(1, "admin.validation.article.categoryRequired"),
-  image: z
-    .string()
-    .url("admin.validation.article.imageInvalid")
-    .optional()
-    .or(z.literal("")),
+  category: z.string().min(1, `${base}.categoryRequired`),
+  image: urlFieldSchema(`${base}.imageInvalid`),
   published: z.boolean(),
 });
 
@@ -29,6 +27,4 @@ export type ArticleFormSchemaType = z.infer<typeof articleFormSchema>;
 
 export const createArticleSchema = articleFormSchema;
 
-export const updateArticleSchema = articleFormSchema.extend({
-  id: z.string().min(1),
-});
+export const updateArticleSchema = withIdExtension(articleFormSchema);

--- a/src/components/features/admin/shared/entity-form-buttons.tsx
+++ b/src/components/features/admin/shared/entity-form-buttons.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+type EntityFormButtonsProps = {
+  mode: "create" | "edit";
+  isPending: boolean;
+  onCancel: () => void;
+  /** All labels already translated. */
+  cancelLabel: string;
+  createLabel: string;
+  updateLabel: string;
+  creatingLabel: string;
+  updatingLabel: string;
+};
+
+/**
+ * Cancel + submit footer shared by the admin entity forms. The submit label
+ * resolves from `mode` and `isPending`; callers pass the translated strings.
+ */
+export function EntityFormButtons({
+  mode,
+  isPending,
+  onCancel,
+  cancelLabel,
+  createLabel,
+  updateLabel,
+  creatingLabel,
+  updatingLabel,
+}: EntityFormButtonsProps) {
+  const submitLabel = isPending
+    ? mode === "create"
+      ? creatingLabel
+      : updatingLabel
+    : mode === "create"
+      ? createLabel
+      : updateLabel;
+
+  return (
+    <div className="flex gap-4">
+      <Button
+        type="button"
+        variant="outline"
+        onClick={onCancel}
+        disabled={isPending}
+      >
+        {cancelLabel}
+      </Button>
+      <Button type="submit" disabled={isPending}>
+        {submitLabel}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/features/combo/combo-detail.tsx
+++ b/src/components/features/combo/combo-detail.tsx
@@ -3,24 +3,16 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useAction } from "next-safe-action/hooks";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { Copy, Edit, ExternalLink, Gauge, Heart, Trash2, Zap } from "lucide-react";
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
+import { useActionToast } from "@/hooks/use-action-toast";
+
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfirmDeleteDialog } from "@/components/shared/confirm-delete-dialog";
 import { ComboDetail as ComboDetailType } from "@/../prisma/query/combo.query";
 
 import { deleteComboAction } from "./combo-action";
@@ -35,14 +27,12 @@ export function ComboDetail({ combo }: ComboDetailProps) {
   const tCommon = useTranslations("common");
   const [deleteOpen, setDeleteOpen] = useState(false);
 
-  const { execute, isPending } = useAction(deleteComboAction, {
+  const { execute, isPending } = useActionToast(deleteComboAction, {
+    successMessage: t("toast.deleted"),
+    errorMessage: t("toast.deleteError"),
     onSuccess: () => {
-      toast.success(t("toast.deleted"));
       router.push("/combos");
       router.refresh();
-    },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("toast.deleteError"));
     },
   });
 
@@ -182,31 +172,18 @@ export function ComboDetail({ combo }: ComboDetailProps) {
         )}
       </div>
 
-      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t("deleteDialog.title")}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {combo.title}
-              <br />
-              <br />
-              {t("deleteDialog.description")}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {tCommon("buttons.cancel")}
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => execute({ id: combo.id })}
-              disabled={isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {isPending ? t("form.deleting") : tCommon("buttons.delete")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmDeleteDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        title={t("deleteDialog.title")}
+        description={t("deleteDialog.description")}
+        itemName={combo.title}
+        isPending={isPending}
+        onConfirm={() => execute({ id: combo.id })}
+        confirmLabel={tCommon("buttons.delete")}
+        cancelLabel={tCommon("buttons.cancel")}
+        deletingLabel={t("form.deleting")}
+      />
     </>
   );
 }

--- a/src/components/features/combo/combo-form.tsx
+++ b/src/components/features/combo/combo-form.tsx
@@ -3,10 +3,8 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
-import { useAction } from "next-safe-action/hooks";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { toast } from "sonner";
 
 import { Tag } from "@/../generated/prisma";
 import {
@@ -33,6 +31,7 @@ import { cn } from "@/lib/utils";
 import { comboFormSchema, ComboFormSchemaType } from "./combo-schema";
 import { createComboAction, updateComboAction } from "./combo-action";
 import { ComboDetail } from "@/../prisma/query/combo.query";
+import { useActionToast } from "@/hooks/use-action-toast";
 
 type CharacterOption = {
   id: string;
@@ -101,30 +100,26 @@ export function ComboForm({
     [characters, selectedGameId],
   );
 
-  const { execute: createExecute, isPending: isCreating } = useAction(
+  const { execute: createExecute, isPending: isCreating } = useActionToast(
     createComboAction,
     {
+      successMessage: t("toast.created"),
+      errorMessage: t("toast.createError"),
       onSuccess: () => {
-        toast.success(t("toast.created"));
         router.push("/combos");
         router.refresh();
-      },
-      onError: ({ error }) => {
-        toast.error(error.serverError ?? t("toast.createError"));
       },
     },
   );
 
-  const { execute: updateExecute, isPending: isUpdating } = useAction(
+  const { execute: updateExecute, isPending: isUpdating } = useActionToast(
     updateComboAction,
     {
+      successMessage: t("toast.updated"),
+      errorMessage: t("toast.updateError"),
       onSuccess: () => {
-        toast.success(t("toast.updated"));
         router.push(`/combos/${combo!.id}`);
         router.refresh();
-      },
-      onError: ({ error }) => {
-        toast.error(error.serverError ?? t("toast.updateError"));
       },
     },
   );

--- a/src/components/features/dashboard/dashboard-hero.tsx
+++ b/src/components/features/dashboard/dashboard-hero.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
+import { formatDateFull } from "@/utils";
 import { CmdkTriggerButton } from "./cmdk-trigger-button";
 import { HeroCarousel, type HeroSlide } from "./hero-carousel";
 
@@ -15,11 +16,7 @@ export async function DashboardHero(props: DashboardHeroProps) {
   const { userName, slides } = props;
   const t = await getTranslations("dashboard");
 
-  const today = new Date().toLocaleDateString("fr-FR", {
-    weekday: "long",
-    day: "2-digit",
-    month: "long",
-  });
+  const today = formatDateFull(new Date());
 
   return (
     <section className="relative grid gap-10 md:grid-cols-[1.15fr_0.85fr] md:items-stretch">

--- a/src/components/features/dashboard/recent-combos-section.tsx
+++ b/src/components/features/dashboard/recent-combos-section.tsx
@@ -1,11 +1,8 @@
-import { Plus } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
 
-import { Button } from "@/components/ui/button";
 import { RecentCombos } from "../../../../prisma/query/combo.query";
 import { ComboCard } from "../combo/combo-card";
-import { SectionHeader } from "./section-header";
+import { RecentSection } from "./recent-section";
 
 type RecentCombosSectionProps = {
   combos: RecentCombos;
@@ -17,33 +14,17 @@ export async function RecentCombosSection({
   const t = await getTranslations("dashboard");
 
   return (
-    <section className="space-y-5">
-      <SectionHeader index="03" title={t("recentCombos.title")} href="/combos" />
-
-      {combos.length === 0 ? (
-        <div className="border-border text-muted-foreground flex flex-col items-center gap-3 rounded-xl border border-dashed py-12 text-center">
-          <p className="font-mono text-sm">{t("recentCombos.empty")}</p>
-          <p className="text-sm">{t("recentCombos.emptyHint")}</p>
-          <Button asChild variant="outline" size="sm" className="mt-1">
-            <Link href="/combos/new">
-              <Plus className="size-4" />
-              {t("actions.newCombo")}
-            </Link>
-          </Button>
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {combos.map((combo, index) => (
-            <div
-              key={combo.id}
-              className="fgc-rise"
-              style={{ animationDelay: `${0.05 * index}s` }}
-            >
-              <ComboCard combo={combo} />
-            </div>
-          ))}
-        </div>
-      )}
-    </section>
+    <RecentSection
+      items={combos}
+      renderItem={(combo) => <ComboCard combo={combo} />}
+      layout="grid"
+      index="03"
+      title={t("recentCombos.title")}
+      viewAllHref="/combos"
+      emptyText={t("recentCombos.empty")}
+      emptyHint={t("recentCombos.emptyHint")}
+      newHref="/combos/new"
+      newLabel={t("actions.newCombo")}
+    />
   );
 }

--- a/src/components/features/dashboard/recent-matches-section.tsx
+++ b/src/components/features/dashboard/recent-matches-section.tsx
@@ -1,11 +1,8 @@
-import { Plus } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
 
-import { Button } from "@/components/ui/button";
 import { RecentMatches } from "../../../../prisma/query/match.query";
+import { RecentSection } from "./recent-section";
 import { ReplayCard } from "./replay-card";
-import { SectionHeader } from "./section-header";
 
 type RecentMatchesSectionProps = {
   matches: RecentMatches;
@@ -17,37 +14,16 @@ export async function RecentMatchesSection({
   const t = await getTranslations("dashboard");
 
   return (
-    <section className="space-y-5">
-      <SectionHeader
-        index="02"
-        title={t("recentMatches.title")}
-        href="/videos"
-      />
-
-      {matches.length === 0 ? (
-        <div className="border-border text-muted-foreground flex flex-col items-center gap-3 rounded-xl border border-dashed py-12 text-center">
-          <p className="font-mono text-sm">{t("recentMatches.empty")}</p>
-          <p className="text-sm">{t("recentMatches.emptyHint")}</p>
-          <Button asChild variant="outline" size="sm" className="mt-1">
-            <Link href="/videos/new">
-              <Plus className="size-4" />
-              {t("actions.newReplay")}
-            </Link>
-          </Button>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {matches.map((match, index) => (
-            <div
-              key={match.id}
-              className="fgc-rise"
-              style={{ animationDelay: `${0.05 * index}s` }}
-            >
-              <ReplayCard match={match} />
-            </div>
-          ))}
-        </div>
-      )}
-    </section>
+    <RecentSection
+      items={matches}
+      renderItem={(match) => <ReplayCard match={match} />}
+      index="02"
+      title={t("recentMatches.title")}
+      viewAllHref="/videos"
+      emptyText={t("recentMatches.empty")}
+      emptyHint={t("recentMatches.emptyHint")}
+      newHref="/videos/new"
+      newLabel={t("actions.newReplay")}
+    />
   );
 }

--- a/src/components/features/dashboard/recent-section.tsx
+++ b/src/components/features/dashboard/recent-section.tsx
@@ -1,0 +1,80 @@
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { SectionHeader } from "./section-header";
+
+type RecentSectionProps<T> = {
+  items: T[];
+  /** Renders one item's card. */
+  renderItem: (item: T, index: number) => ReactNode;
+  /** `grid` (3-col cards) or `list` (stacked rows). Defaults to `list`. */
+  layout?: "grid" | "list";
+  /** Section header order index, e.g. `"01"`. */
+  index: string;
+  /** Section title (already translated). */
+  title: string;
+  viewAllHref: string;
+  /** Empty-state copy (already translated). */
+  emptyText: string;
+  emptyHint: string;
+  /** "Create new" call to action. */
+  newHref: string;
+  newLabel: string;
+};
+
+/**
+ * Dashboard "recent <entity>" section: header + empty state + animated card
+ * grid/list. Generic over the item type — callers provide the card via
+ * {@link RecentSectionProps.renderItem}.
+ */
+export function RecentSection<T extends { id: string }>({
+  items,
+  renderItem,
+  layout = "list",
+  index,
+  title,
+  viewAllHref,
+  emptyText,
+  emptyHint,
+  newHref,
+  newLabel,
+}: RecentSectionProps<T>) {
+  return (
+    <section className="space-y-5">
+      <SectionHeader index={index} title={title} href={viewAllHref} />
+
+      {items.length === 0 ? (
+        <div className="border-border text-muted-foreground flex flex-col items-center gap-3 rounded-xl border border-dashed py-12 text-center">
+          <p className="font-mono text-sm">{emptyText}</p>
+          <p className="text-sm">{emptyHint}</p>
+          <Button asChild variant="outline" size="sm" className="mt-1">
+            <Link href={newHref}>
+              <Plus className="size-4" />
+              {newLabel}
+            </Link>
+          </Button>
+        </div>
+      ) : (
+        <div
+          className={
+            layout === "grid"
+              ? "grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3"
+              : "space-y-3"
+          }
+        >
+          {items.map((item, i) => (
+            <div
+              key={item.id}
+              className="fgc-rise"
+              style={{ animationDelay: `${0.05 * i}s` }}
+            >
+              {renderItem(item, i)}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/features/dashboard/recent-strategy-matrices-section.tsx
+++ b/src/components/features/dashboard/recent-strategy-matrices-section.tsx
@@ -1,10 +1,7 @@
-import { Plus } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
 
-import { Button } from "@/components/ui/button";
 import { RecentStrategyMatrices } from "../../../../prisma/query/strategy-matrix.query";
-import { SectionHeader } from "./section-header";
+import { RecentSection } from "./recent-section";
 import { StrategyMatrixCard } from "./strategy-matrix-card";
 
 type RecentStrategyMatricesSectionProps = {
@@ -17,37 +14,16 @@ export async function RecentStrategyMatricesSection({
   const t = await getTranslations("dashboard");
 
   return (
-    <section className="space-y-5">
-      <SectionHeader
-        index="01"
-        title={t("recentMatrices.title")}
-        href="/notes/strategy"
-      />
-
-      {matrices.length === 0 ? (
-        <div className="border-border text-muted-foreground flex flex-col items-center gap-3 rounded-xl border border-dashed py-12 text-center">
-          <p className="font-mono text-sm">{t("recentMatrices.empty")}</p>
-          <p className="text-sm">{t("recentMatrices.emptyHint")}</p>
-          <Button asChild variant="outline" size="sm" className="mt-1">
-            <Link href="/notes/strategy/new">
-              <Plus className="size-4" />
-              {t("actions.newMatrix")}
-            </Link>
-          </Button>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {matrices.map((matrix, index) => (
-            <div
-              key={matrix.id}
-              className="fgc-rise"
-              style={{ animationDelay: `${0.05 * index}s` }}
-            >
-              <StrategyMatrixCard matrix={matrix} />
-            </div>
-          ))}
-        </div>
-      )}
-    </section>
+    <RecentSection
+      items={matrices}
+      renderItem={(matrix) => <StrategyMatrixCard matrix={matrix} />}
+      index="01"
+      title={t("recentMatrices.title")}
+      viewAllHref="/notes/strategy"
+      emptyText={t("recentMatrices.empty")}
+      emptyHint={t("recentMatrices.emptyHint")}
+      newHref="/notes/strategy/new"
+      newLabel={t("actions.newMatrix")}
+    />
   );
 }

--- a/src/components/features/dashboard/replay-card.tsx
+++ b/src/components/features/dashboard/replay-card.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import type { Translator } from "@/types/translator";
 import { formatDate, formatTime } from "@/utils";
 import { getTranslations } from "next-intl/server";
 import Link from "next/link";
@@ -13,7 +14,7 @@ interface ReplayCardProps {
 export async function ReplayCard({ match }: ReplayCardProps) {
   const t = await getTranslations("dashboard");
   const tMatch = await getTranslations("match");
-  const translateMatch = tMatch as unknown as (key: string) => string;
+  const translateMatch = tMatch as unknown as Translator;
 
   return (
     <Link href={`/videos/${match.id}`}>

--- a/src/components/features/glossary/glossary-article-card.tsx
+++ b/src/components/features/glossary/glossary-article-card.tsx
@@ -2,18 +2,11 @@ import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import type { PublishedArticles } from "../../../../prisma/query/glossary.query";
+import { formatDate } from "@/utils";
 import { CategoryBadge } from "./glossary-category-badge";
 
 interface ArticleCardProps {
   article: PublishedArticles[number];
-}
-
-function formatDate(date: Date) {
-  return new Date(date).toLocaleDateString("fr-FR", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  });
 }
 
 export async function ArticleCard({ article }: ArticleCardProps) {

--- a/src/components/features/glossary/glossary-article-detail.tsx
+++ b/src/components/features/glossary/glossary-article-detail.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ArticleDetail } from "../../../../prisma/query/glossary.query";
+import { formatDate } from "@/utils";
 import { CategoryBadge } from "./glossary-category-badge";
 
 interface ArticleDetailProps {
@@ -35,15 +36,11 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
         <div className="text-muted-foreground flex items-center gap-4 text-sm">
           {article.category && <CategoryBadge category={article.category} />}
           <time dateTime={article.createdAt.toString()}>
-            {t("detail.createdAt", {
-              date: new Date(article.createdAt).toLocaleDateString(),
-            })}
+            {t("detail.createdAt", { date: formatDate(article.createdAt) })}
           </time>
           {article.updatedAt && (
             <time dateTime={article.updatedAt.toString()}>
-              {t("detail.updatedAt", {
-                date: new Date(article.updatedAt).toLocaleDateString(),
-              })}
+              {t("detail.updatedAt", { date: formatDate(article.updatedAt) })}
             </time>
           )}
         </div>
@@ -137,7 +134,7 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
               {t("detail.createdBy", { name: article.creator.name })}
             </p>
             <p className="text-muted-foreground text-xs">
-              {new Date(article.createdAt).toLocaleDateString()}
+              {formatDate(article.createdAt)}
             </p>
           </div>
         </div>

--- a/src/components/features/match/delete-match-dialog.tsx
+++ b/src/components/features/match/delete-match-dialog.tsx
@@ -14,9 +14,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useAction } from "next-safe-action/hooks";
 import { useTranslations } from "next-intl";
-import { toast } from "sonner";
+import { useActionToast } from "@/hooks/use-action-toast";
 import { deleteMatchAction } from "./match-action";
 
 interface DeleteMatchDialogProps {
@@ -32,14 +31,12 @@ export function DeleteMatchDialog({
   const t = useTranslations("match");
   const tCommon = useTranslations("common");
 
-  const { execute, isPending, result } = useAction(deleteMatchAction, {
+  const { execute, isPending, result } = useActionToast(deleteMatchAction, {
+    successMessage: t("toast.deleted"),
+    errorMessage: t("toast.deleteError"),
     onSuccess: () => {
-      toast.success(t("toast.deleted"));
       router.replace("/dashboard");
       router.refresh();
-    },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("toast.deleteError"));
     },
   });
 

--- a/src/components/features/match/match-header.tsx
+++ b/src/components/features/match/match-header.tsx
@@ -7,11 +7,11 @@ import { DeleteMatchDialog } from "@/components/features/match/delete-match-dial
 import {
   getMatchTypeLabel,
   MatchStatusBadge,
-  type MatchTranslator,
 } from "@/components/features/match/match-labels";
 import { MatchReportDialog } from "@/components/features/video/match-report-dialog";
 import type { MatchReportData } from "@/components/features/video/match-report-schema";
 import { Button } from "@/components/ui/button";
+import type { Translator } from "@/types/translator";
 import { formatDate, formatTime } from "@/utils";
 
 type MatchHeaderProps = {
@@ -44,7 +44,7 @@ export async function MatchHeader(props: MatchHeaderProps) {
             <span>
               {getMatchTypeLabel(
                 match.matchType,
-                t as unknown as MatchTranslator,
+                t as unknown as Translator,
               )}
             </span>
           </div>

--- a/src/components/features/match/match-labels.tsx
+++ b/src/components/features/match/match-labels.tsx
@@ -3,12 +3,11 @@ import { getTranslations } from "next-intl/server";
 import type { MatchStatus, MatchType } from "@/../generated/prisma";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-
-export type MatchTranslator = (key: string) => string;
+import type { Translator } from "@/types/translator";
 
 export function getMatchTypeLabel(
   matchType: MatchType,
-  t: MatchTranslator,
+  t: Translator,
 ): string {
   switch (matchType) {
     case "RANKED":
@@ -22,7 +21,7 @@ export function getMatchTypeLabel(
 
 export function getStatusLabel(
   status: MatchStatus,
-  t: MatchTranslator,
+  t: Translator,
 ): string {
   switch (status) {
     case "DRAFT":
@@ -62,7 +61,7 @@ export async function MatchStatusBadge(props: MatchStatusBadgeProps) {
         className,
       )}
     >
-      {getStatusLabel(status, t as unknown as MatchTranslator)}
+      {getStatusLabel(status, t as unknown as Translator)}
     </Badge>
   );
 }

--- a/src/components/features/memo/memo-form.tsx
+++ b/src/components/features/memo/memo-form.tsx
@@ -15,14 +15,13 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Eye, Pencil } from "lucide-react";
-import { useAction } from "next-safe-action/hooks";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { toast } from "sonner";
+import { useActionToast } from "@/hooks/use-action-toast";
 import { createMemoAction, updateMemoAction } from "./memo-action";
 import {
   MAX_MEMO_CONTENT_LENGTH,
@@ -56,23 +55,19 @@ export function MemoForm(props: Props) {
     mode: "onSubmit",
   });
 
-  const createAction = useAction(createMemoAction, {
+  const createAction = useActionToast(createMemoAction, {
+    successMessage: t("created"),
+    errorMessage: t("createError"),
     onSuccess: ({ data }) => {
-      toast.success(t("created"));
       if (data?.id) router.push(`/notes/memo/${data.id}`);
-    },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("createError"));
     },
   });
 
-  const updateAction = useAction(updateMemoAction, {
+  const updateAction = useActionToast(updateMemoAction, {
+    successMessage: t("updated"),
+    errorMessage: t("updateError"),
     onSuccess: () => {
-      toast.success(t("updated"));
       router.refresh();
-    },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("updateError"));
     },
   });
 

--- a/src/components/features/memo/memo-list.tsx
+++ b/src/components/features/memo/memo-list.tsx
@@ -19,11 +19,11 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { FolderOpen, Trash2 } from "lucide-react";
-import { useAction } from "next-safe-action/hooks";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { toast } from "sonner";
+import { useActionToast } from "@/hooks/use-action-toast";
+import { formatDate } from "@/utils";
 import type { MemoListItem } from "../../../../prisma/query/memo.query";
 import { deleteMemoAction } from "./memo-action";
 import { MemoVisualizeDialog } from "./memo-visualize-dialog";
@@ -36,13 +36,11 @@ export function MemoList({ memos }: Props) {
   const router = useRouter();
   const t = useTranslations("memo.list");
   const tCommon = useTranslations("common.buttons");
-  const { execute, isPending } = useAction(deleteMemoAction, {
+  const { execute, isPending } = useActionToast(deleteMemoAction, {
+    successMessage: t("deleted"),
+    errorMessage: t("deleteError"),
     onSuccess: () => {
-      toast.success(t("deleted"));
       router.refresh();
-    },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("deleteError"));
     },
   });
 
@@ -70,12 +68,7 @@ export function MemoList({ memos }: Props) {
             )}
           </div>
           <div className="text-muted-foreground text-xs">
-            {t("updatedOn")}{" "}
-            {new Date(memo.updatedAt).toLocaleDateString("fr-FR", {
-              day: "2-digit",
-              month: "short",
-              year: "numeric",
-            })}
+            {t("updatedOn")} {formatDate(memo.updatedAt)}
           </div>
           <div className="mt-auto flex justify-end gap-2">
             <Tooltip>

--- a/src/components/features/strategy-matrix/strategy-matrix-ai-fill-button.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-ai-fill-button.tsx
@@ -13,9 +13,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { Loader2, Sparkles } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useAction } from "next-safe-action/hooks";
 import { useState } from "react";
 import { toast } from "sonner";
+import { useActionToast } from "@/hooks/use-action-toast";
 import { fillStrategyMatrixWithAiAction } from "./strategy-matrix-ai-action";
 import type { Axis, Cell } from "./strategy-matrix-schema";
 
@@ -46,17 +46,18 @@ export function StrategyMatrixAiFillButton({
   const t = useTranslations("strategyMatrix");
   const tc = useTranslations("common");
 
-  const { execute, isPending } = useAction(fillStrategyMatrixWithAiAction, {
+  const { execute, isPending } = useActionToast(fillStrategyMatrixWithAiAction, {
+    successMessage: (data) =>
+      data?.cells && data.cells.length > 0
+        ? t("aiFill.success", { count: data.cells.length })
+        : undefined,
+    errorMessage: t("aiFill.error"),
     onSuccess: ({ data }) => {
       if (!data?.cells || data.cells.length === 0) {
         toast.error(t("aiFill.empty"));
         return;
       }
       onCellsGenerated(data.cells);
-      toast.success(t("aiFill.success", { count: data.cells.length }));
-    },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("aiFill.error"));
     },
   });
 

--- a/src/components/features/strategy-matrix/strategy-matrix-form.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-form.tsx
@@ -11,13 +11,13 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import type { Translator } from "@/types/translator";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslations } from "next-intl";
-import { useAction } from "next-safe-action/hooks";
+import { useActionToast } from "@/hooks/use-action-toast";
 import { useRouter } from "next/navigation";
 import { useState, type ReactNode } from "react";
 import { useForm } from "react-hook-form";
-import { toast } from "sonner";
 import type {
   CharacterOption,
   GameOption,
@@ -40,7 +40,6 @@ import {
 import {
   resolveStrategyMatrixTemplates,
   type StrategyMatrixTemplate,
-  type TemplateTranslator,
 } from "./strategy-matrix-templates";
 import { StrategyMatrixTemplateSelector } from "./strategy-matrix-template-selector";
 import {
@@ -112,7 +111,7 @@ export function StrategyMatrixForm(props: Props) {
   const t = useTranslations("strategyMatrix");
   const tc = useTranslations("common");
   const templates = resolveStrategyMatrixTemplates(
-    t as unknown as TemplateTranslator,
+    t as unknown as Translator,
   );
   const fallback = props.initialTemplate ?? templates[0];
   const initialValues: StrategyMatrixCreateInput =
@@ -145,23 +144,19 @@ export function StrategyMatrixForm(props: Props) {
   const myCharacterId = form.watch("myCharacterId");
   const opponentCharacterId = form.watch("opponentCharacterId");
 
-  const createAction = useAction(createStrategyMatrixAction, {
+  const createAction = useActionToast(createStrategyMatrixAction, {
+    successMessage: t("form.toast.created"),
+    errorMessage: t("form.toast.createError"),
     onSuccess: ({ data }) => {
-      toast.success(t("form.toast.created"));
       if (data?.id) router.push(`/notes/strategy/${data.id}`);
-    },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("form.toast.createError"));
     },
   });
 
-  const updateAction = useAction(updateStrategyMatrixAction, {
+  const updateAction = useActionToast(updateStrategyMatrixAction, {
+    successMessage: t("form.toast.updated"),
+    errorMessage: t("form.toast.updateError"),
     onSuccess: () => {
-      toast.success(t("form.toast.updated"));
       router.refresh();
-    },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("form.toast.updateError"));
     },
   });
 

--- a/src/components/features/strategy-matrix/strategy-matrix-list.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-list.tsx
@@ -20,10 +20,9 @@ import {
 } from "@/components/ui/tooltip";
 import { FolderOpen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useAction } from "next-safe-action/hooks";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { toast } from "sonner";
+import { useActionToast } from "@/hooks/use-action-toast";
 import { StrategyMatrixVisualizeDialog } from "./strategy-matrix-visualize-dialog";
 import { axisSchema } from "./strategy-matrix-schema";
 import type { StrategyMatrixListItem } from "../../../../prisma/query/strategy-matrix.query";
@@ -42,13 +41,11 @@ export function StrategyMatrixList({ matrices }: Props) {
   const router = useRouter();
   const t = useTranslations("strategyMatrix");
   const tc = useTranslations("common");
-  const { execute, isPending } = useAction(deleteStrategyMatrixAction, {
+  const { execute, isPending } = useActionToast(deleteStrategyMatrixAction, {
+    successMessage: t("list.toast.deleted"),
+    errorMessage: t("list.toast.deleteError"),
     onSuccess: () => {
-      toast.success(t("list.toast.deleted"));
       router.refresh();
-    },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("list.toast.deleteError"));
     },
   });
 

--- a/src/components/features/strategy-matrix/strategy-matrix-template-selector.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-template-selector.tsx
@@ -3,10 +3,10 @@
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { useTranslations } from "next-intl";
+import type { Translator } from "@/types/translator";
 import {
   resolveStrategyMatrixTemplates,
   type StrategyMatrixTemplate,
-  type TemplateTranslator,
 } from "./strategy-matrix-templates";
 
 type Props = {
@@ -16,7 +16,7 @@ type Props = {
 export function StrategyMatrixTemplateSelector({ onSelect }: Props) {
   const t = useTranslations("strategyMatrix");
   const templates = resolveStrategyMatrixTemplates(
-    t as unknown as TemplateTranslator,
+    t as unknown as Translator,
   );
 
   return (

--- a/src/components/features/strategy-matrix/strategy-matrix-templates.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-templates.ts
@@ -1,3 +1,4 @@
+import type { Translator } from "@/types/translator";
 import type { Axis, Cell } from "./strategy-matrix-schema";
 import { createEmptyCells } from "./strategy-matrix-types";
 
@@ -12,12 +13,11 @@ export type StrategyMatrixTemplate = {
 };
 
 /**
- * Translator scoped to the `strategyMatrix` namespace.
- * Templates store i18n KEYS (relative to that namespace) as their labels —
- * hooks cannot run in this module, so labels are resolved at render time by the
- * consuming components via {@link resolveStrategyMatrixTemplates}.
+ * Templates store i18n KEYS (relative to the `strategyMatrix` namespace) as their
+ * labels — hooks cannot run in this module, so labels are resolved at render time
+ * by the consuming components via {@link resolveStrategyMatrixTemplates}, passing a
+ * scoped {@link Translator}.
  */
-export type TemplateTranslator = (key: string) => string;
 
 const hpMeterMyAxis: Axis = {
   label: "templates.hpVsMeter.myAxisLabel",
@@ -106,7 +106,7 @@ export const STRATEGY_MATRIX_TEMPLATES: StrategyMatrixTemplate[] = [
   },
 ];
 
-function resolveAxis(axis: Axis, t: TemplateTranslator): Axis {
+function resolveAxis(axis: Axis, t: Translator): Axis {
   return {
     ...axis,
     label: t(axis.label),
@@ -119,7 +119,7 @@ function resolveAxis(axis: Axis, t: TemplateTranslator): Axis {
  * localized labels. Cells only reference level ids, so they are left untouched.
  */
 export function resolveStrategyMatrixTemplates(
-  t: TemplateTranslator,
+  t: Translator,
 ): StrategyMatrixTemplate[] {
   return STRATEGY_MATRIX_TEMPLATES.map((template) => ({
     ...template,

--- a/src/components/features/video/match-report-dialog.tsx
+++ b/src/components/features/video/match-report-dialog.tsx
@@ -31,8 +31,7 @@ import { CheckCircle, FileText, Loader2, Target } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { useAction } from "next-safe-action/hooks";
-import { toast } from "sonner";
+import { useActionToast } from "@/hooks/use-action-toast";
 import { generateReportAction } from "./match-report-action";
 import type { MatchReportData } from "./match-report-schema";
 
@@ -54,16 +53,14 @@ export function MatchReportDialog({
   const [report, setReport] = useState<MatchReportData | null>(existingReport);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  const { execute, isPending } = useAction(generateReportAction, {
+  const { execute, isPending } = useActionToast(generateReportAction, {
+    successMessage: (data) => (data ? t("generated") : undefined),
+    errorMessage: t("generationError"),
     onSuccess: ({ data }) => {
       if (data) {
         setReport(data);
-        toast.success(t("generated"));
         router.refresh();
       }
-    },
-    onError: ({ error }) => {
-      toast.error(error.serverError ?? t("generationError"));
     },
   });
 

--- a/src/components/features/video/note-list.tsx
+++ b/src/components/features/video/note-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import Link from "next/link";
 import { Swords, Trash2 } from "lucide-react";
@@ -9,17 +9,9 @@ import { useAction } from "next-safe-action/hooks";
 import { useTranslations } from "next-intl";
 
 import { Note, Tag } from "@/../generated/prisma";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
+import { ConfirmDeleteDialog } from "@/components/shared/confirm-delete-dialog";
+import { useDeleteDialog } from "@/hooks/use-delete-dialog";
 import { cn } from "@/lib/utils";
 import { useVideoPlayerStore } from "@/stores/video-player";
 import { formatTime } from "@/utils";
@@ -122,17 +114,11 @@ export function NoteList(props: NoteListProps) {
   const seekToTimestamp = useVideoPlayerStore((state) => state.seekToTimestamp);
   const currentTime = useVideoPlayerStore((state) => state.currentTime);
 
-  const [deleteDialog, setDeleteDialog] = useState<{
-    open: boolean;
-    note: NoteWithTags | null;
-  }>({
-    open: false,
-    note: null,
-  });
+  const deleteDialog = useDeleteDialog<NoteWithTags>();
 
   const { execute, isPending, result } = useAction(deleteNoteAction, {
     onSuccess: () => {
-      setDeleteDialog({ open: false, note: null });
+      deleteDialog.close();
       router.refresh();
     },
   });
@@ -144,13 +130,9 @@ export function NoteList(props: NoteListProps) {
     [seekToTimestamp],
   );
 
-  const openDeleteDialog = (note: NoteWithTags) => {
-    setDeleteDialog({ open: true, note });
-  };
-
   const handleDelete = () => {
-    if (deleteDialog.note) {
-      execute({ noteId: deleteDialog.note.id });
+    if (deleteDialog.item) {
+      execute({ noteId: deleteDialog.item.id });
     }
   };
 
@@ -180,46 +162,24 @@ export function NoteList(props: NoteListProps) {
             note={note}
             isActive={note.id === activeNoteId}
             onClick={handleNoteClick}
-            onDelete={openDeleteDialog}
+            onDelete={deleteDialog.openWith}
           />
         ))}
       </div>
 
-      <AlertDialog
+      <ConfirmDeleteDialog
         open={deleteDialog.open}
-        onOpenChange={(open) =>
-          !open && setDeleteDialog({ open: false, note: null })
-        }
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t("deleteTitle")}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {deleteDialog.note?.content}
-              <br />
-              <br />
-              {t("deleteIrreversible")}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {tCommon("cancel")}
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              disabled={isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {isPending ? t("deleting") : tCommon("delete")}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-          {result.serverError && (
-            <p className="text-destructive mt-2 text-sm">
-              {result.serverError}
-            </p>
-          )}
-        </AlertDialogContent>
-      </AlertDialog>
+        onOpenChange={deleteDialog.onOpenChange}
+        title={t("deleteTitle")}
+        description={t("deleteIrreversible")}
+        itemName={deleteDialog.item?.content}
+        isPending={isPending}
+        onConfirm={handleDelete}
+        confirmLabel={tCommon("delete")}
+        cancelLabel={tCommon("cancel")}
+        deletingLabel={t("deleting")}
+        serverError={result.serverError}
+      />
     </>
   );
 }

--- a/src/components/shared/confirm-delete-dialog.tsx
+++ b/src/components/shared/confirm-delete-dialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+type ConfirmDeleteDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Dialog heading (already translated). */
+  title: string;
+  /** Body copy below the optional item name (already translated). */
+  description: string;
+  /** Name/content of the item being deleted, shown above the description. */
+  itemName?: string | null;
+  isPending: boolean;
+  onConfirm: () => void;
+  confirmLabel: string;
+  cancelLabel: string;
+  /** Label shown on the confirm button while the deletion is running. */
+  deletingLabel: string;
+  /** Optional server error rendered under the footer. */
+  serverError?: string | null;
+};
+
+/**
+ * Controlled confirmation dialog for destructive deletions. Pass already
+ * translated strings — it is i18n-namespace agnostic so any feature can reuse it.
+ */
+export function ConfirmDeleteDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  itemName,
+  isPending,
+  onConfirm,
+  confirmLabel,
+  cancelLabel,
+  deletingLabel,
+  serverError,
+}: ConfirmDeleteDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {itemName ? (
+              <>
+                {itemName}
+                <br />
+                <br />
+              </>
+            ) : null}
+            {description}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>
+            {cancelLabel}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isPending}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isPending ? deletingLabel : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+        {serverError ? (
+          <p className="text-destructive mt-2 text-sm">{serverError}</p>
+        ) : null}
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/hooks/use-action-toast.ts
+++ b/src/hooks/use-action-toast.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useAction } from "next-safe-action/hooks";
+import type {
+  HookCallbacks,
+  HookSafeActionFn,
+  UseActionHookReturn,
+} from "next-safe-action/hooks";
+import { toast } from "sonner";
+
+/**
+ * Any next-safe-action client action. Every concrete action is assignable to
+ * this (params are contravariant, so `never` accepts any input) — it lets the
+ * hook stay generic without naming the library's internal schema type.
+ */
+type AnyHookSafeActionFn = (input: never) => Promise<unknown>;
+
+type InferOnSuccess<Fn> =
+  Fn extends HookSafeActionFn<infer SE, infer S, infer CVE, infer Data>
+    ? NonNullable<HookCallbacks<SE, S, CVE, Data>["onSuccess"]>
+    : never;
+
+type InferOnError<Fn> =
+  Fn extends HookSafeActionFn<infer SE, infer S, infer CVE, infer Data>
+    ? NonNullable<HookCallbacks<SE, S, CVE, Data>["onError"]>
+    : never;
+
+type InferReturn<Fn> =
+  Fn extends HookSafeActionFn<infer SE, infer S, infer CVE, infer Data>
+    ? UseActionHookReturn<SE, S, CVE, Data>
+    : never;
+
+type InferData<Fn> = Parameters<InferOnSuccess<Fn>>[0] extends { data: infer D }
+  ? D
+  : never;
+
+type UseActionToastOptions<Fn extends AnyHookSafeActionFn> = {
+  /**
+   * Success toast. A string shows unconditionally; a function lets the toast
+   * depend on the returned data (return `undefined` to skip the toast).
+   */
+  successMessage?: string | ((data: InferData<Fn>) => string | null | undefined);
+  /** Fallback error toast — `error.serverError` takes precedence when present. */
+  errorMessage?: string;
+  /** Extra side effects on success (router navigation, dialog reset, …). */
+  onSuccess?: InferOnSuccess<Fn>;
+  /** Extra side effects on error. */
+  onError?: InferOnError<Fn>;
+};
+
+/**
+ * `useAction` wrapper that centralizes the repeated sonner toast boilerplate
+ * (`toast.success(t(...))` + `toast.error(error.serverError ?? t(...))`). Pass
+ * already-translated messages; extra side effects stay overridable via
+ * `onSuccess` / `onError`.
+ */
+export function useActionToast<Fn extends AnyHookSafeActionFn>(
+  action: Fn,
+  options: UseActionToastOptions<Fn> = {},
+): InferReturn<Fn> {
+  const { successMessage, errorMessage, onSuccess, onError } = options;
+
+  return useAction(action as unknown as HookSafeActionFn<unknown, undefined, unknown, unknown>, {
+    onSuccess: (args) => {
+      const message =
+        typeof successMessage === "function"
+          ? successMessage(args.data as InferData<Fn>)
+          : successMessage;
+      if (message) {
+        toast.success(message);
+      }
+      (onSuccess as ((args: unknown) => void) | undefined)?.(args);
+    },
+    onError: (args) => {
+      const serverError = args.error.serverError as string | undefined;
+      const fallback = serverError ?? errorMessage;
+      if (fallback) {
+        toast.error(fallback);
+      }
+      (onError as ((args: unknown) => void) | undefined)?.(args);
+    },
+  }) as unknown as InferReturn<Fn>;
+}

--- a/src/hooks/use-delete-dialog.ts
+++ b/src/hooks/use-delete-dialog.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+
+type DeleteDialogState<T> = {
+  open: boolean;
+  item: T | null;
+};
+
+/**
+ * State helper for a controlled delete confirmation dialog tied to a list item.
+ * Replaces the repeated `useState<{ open; item }>` + open/close handlers.
+ */
+export function useDeleteDialog<T>() {
+  const [state, setState] = useState<DeleteDialogState<T>>({
+    open: false,
+    item: null,
+  });
+
+  return {
+    open: state.open,
+    item: state.item,
+    /** Open the dialog for the given item. */
+    openWith: (item: T) => setState({ open: true, item }),
+    /** Close and clear the selected item. */
+    close: () => setState({ open: false, item: null }),
+    /** `onOpenChange` handler for the dialog — clears the item on close. */
+    onOpenChange: (open: boolean) => {
+      if (!open) setState({ open: false, item: null });
+    },
+  };
+}

--- a/src/lib/validations/admin-schemas.ts
+++ b/src/lib/validations/admin-schemas.ts
@@ -1,0 +1,54 @@
+import z from "zod";
+
+/**
+ * Shared Zod building blocks for the admin CRUD entities (game / character /
+ * article). They keep each entity's exact min/max bounds and stable i18n error
+ * keys (translated at render by the shadcn `FormMessage`) while removing the
+ * duplicated slug / name / url / id fragments.
+ */
+
+/** A URL-safe slug: lowercase letters, digits and hyphens only. */
+export const SLUG_REGEX = /^[a-z0-9-]+$/;
+
+type SlugOptions = {
+  base: string;
+  min: number;
+  max: number;
+  /** Error key suffix for the `.min` rule (defaults to `slugMin`). */
+  minKey?: string;
+};
+
+/** `<min>..<max>` slug constrained by {@link SLUG_REGEX}. */
+export function slugSchema({ base, min, max, minKey = "slugMin" }: SlugOptions) {
+  return z
+    .string()
+    .min(min, `${base}.${minKey}`)
+    .max(max, `${base}.slugMax`)
+    .regex(SLUG_REGEX, `${base}.slugFormat`);
+}
+
+type NameOptions = {
+  base: string;
+  min: number;
+  max: number;
+  /** Field prefix for the error keys (`name` by default, `title` for articles). */
+  field?: string;
+};
+
+/** Bounded display name / title with `<field>Min` / `<field>Max` error keys. */
+export function nameSchema({ base, min, max, field = "name" }: NameOptions) {
+  return z
+    .string()
+    .min(min, `${base}.${field}Min`)
+    .max(max, `${base}.${field}Max`);
+}
+
+/** Optional URL that also accepts the empty string (cleared input). */
+export function urlFieldSchema(invalidKey: string) {
+  return z.string().url(invalidKey).optional().or(z.literal(""));
+}
+
+/** Extend a form schema with the required `id` used by update actions. */
+export function withIdExtension<T extends z.ZodRawShape>(schema: z.ZodObject<T>) {
+  return schema.extend({ id: z.string().min(1) });
+}

--- a/src/types/translator.ts
+++ b/src/types/translator.ts
@@ -1,0 +1,8 @@
+/**
+ * Translator function type for i18n scopes.
+ *
+ * A scoped translator mapping i18n keys to localized strings, as returned by
+ * `useTranslations(namespace)` / `getTranslations(namespace)`. Use it instead of
+ * re-declaring `(key: string) => string` per feature.
+ */
+export type Translator = (key: string) => string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,3 +16,19 @@ export function formatDate(date: Date | string): string {
     year: "numeric",
   });
 }
+
+export function formatDateLong(date: Date | string): string {
+  return new Date(date).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export function formatDateFull(date: Date | string): string {
+  return new Date(date).toLocaleDateString("fr-FR", {
+    weekday: "long",
+    day: "2-digit",
+    month: "long",
+  });
+}


### PR DESCRIPTION
## Summary

- Shared `Translator` type replacing 3 duplicate declarations
- New date utilities `formatDateLong`/`formatDateFull` + migrate ~9 inline `toLocaleDateString` sites
- Reuse `@/lib/slug` `generateSlug` in article form (drop local copy)
- Shared admin Zod validators for game/character/article schemas
- Reusable `ConfirmDeleteDialog` + `useDeleteDialog` hook across 5 lists
- Generic `RecentSection` component backing 3 dashboard sections
- `useActionToast` hook consolidating 16 next-safe-action toast patterns
- `EntityFormButtons` footer shared by 3 admin forms

## Files

- 41 changed files (41 total: 34 modified, 7 new)
- **763 insertions, 692 deletions** (net +71 LOC reduction)
- Shared components in `src/components/shared/`, `src/hooks/`, `src/lib/validations/`, `src/types/`

## Testing

✓ TypeScript strict mode  
✓ ESLint clean  
✓ 162 unit tests passing  
✓ Production build successful  

## Notes

- Deferred: `makeEntityActions` action factory (see `.claude/rules/dry.md`) — generic Prisma typing + RAG hook safety require dedicated review
- No breaking changes; existing APIs preserved