### PR TITLE
refactor(dry): extract shared admin action helpers

### DIFF
--- a/.claude/rules/dry.md
+++ b/.claude/rules/dry.md
@@ -25,7 +25,8 @@ Before duplicating logic, markup or config, reuse the shared building blocks bel
 
 Resolved (2026-06-21): inline delete dialog (`ConfirmDeleteDialog` + `useDeleteDialog`), dashboard `recent-*` (`RecentSection`), toast boilerplate (`useActionToast`, 16 sites), `Translator` type, `formatDate` underuse, shared admin Zod fragments + `EntityFormButtons`.
 
-Remaining (gated — dedicated PR):
+Resolved (2026-06-22): admin CRUD actions — extracted closure-based helpers in `@/lib/admin/entity-actions` (`runDelete`, `assertSlugAvailable`, `normalizeOptionalUrl`). A single generic `makeEntityActions` factory was **declined on purpose**: the create/update divergences (character `gameNotFound` pre-check, article `createdBy` + RAG `after()` hook + `image ?? null`, per-entity slug scoping) live in the semantically important parts, and a Prisma-model-generic param has no clean shared delegate type → it would force `any` (the codebase has none). The closure helpers remove the real duplication while keeping each action explicit and typed. Note: a Next.js `"use server"` file must export literal async functions, so the delete action stays inline and only its body (`runDelete`) is shared — a `makeDeleteAction` that *returns* the action fails the build.
 
-1. **Admin CRUD action factory** — game / character / action create+update+delete actions are still ~67% identical. A `makeEntityActions({ model, schemas, revalidatePaths, slugScope, getCreateData, getUpdateData, onCreateHook?, onUpdateHook? })` factory would collapse them. Deferred because the generic Prisma-model typing is delicate and must not break the article RAG `after()`/`embedGlossaryArticleIfNeeded` hook — design before coding.
-2. Two delete dialogs still use the per-card `AlertDialogTrigger` idiom (`strategy-matrix-list`, `memo-list`); migrate to `ConfirmDeleteDialog` only if a controlled-state refactor of those loops is worthwhile.
+Remaining (optional):
+
+1. Two delete dialogs still use the per-card `AlertDialogTrigger` idiom (`strategy-matrix-list`, `memo-list`); migrate to `ConfirmDeleteDialog` only if a controlled-state refactor of those loops is worthwhile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## 2026-06-22
 
+### Refactor: Extract shared admin action helpers (runDelete/assertSlugAvailable/normalizeOptionalUrl) for game/character/article actions (DRY)
+
 ### Refactor: Add a shared Translator type and replace the duplicated MatchTranslator/TemplateTranslator/inline casts (DRY)
 
 ### Refactor: Add formatDateLong/formatDateFull utils and route ~9 inline toLocaleDateString call sites through @/utils (DRY)

--- a/src/components/features/admin/character/character-action.ts
+++ b/src/components/features/admin/character/character-action.ts
@@ -2,6 +2,11 @@
 
 import { prisma } from "@/lib/prisma";
 import { adminActionClient } from "@/lib/admin-action";
+import {
+  assertSlugAvailable,
+  normalizeOptionalUrl,
+  runDelete,
+} from "@/lib/admin/entity-actions";
 import { revalidatePath } from "next/cache";
 import { getTranslations } from "next-intl/server";
 import {
@@ -21,20 +26,17 @@ export const createCharacterAction = adminActionClient
       throw new Error(t("character.errors.gameNotFound"));
     }
 
-    const existing = await prisma.character.findFirst({
-      where: { gameId, slug },
-    });
-
-    if (existing) {
-      throw new Error(t("character.errors.slugExists"));
-    }
+    await assertSlugAvailable(
+      () => prisma.character.findFirst({ where: { gameId, slug } }),
+      t("character.errors.slugExists"),
+    );
 
     const character = await prisma.character.create({
       data: {
         gameId,
         name,
         slug,
-        iconUrl: iconUrl && iconUrl.length > 0 ? iconUrl : null,
+        iconUrl: normalizeOptionalUrl(iconUrl),
       },
     });
 
@@ -55,17 +57,10 @@ export const updateCharacterAction = adminActionClient
       throw new Error(t("character.errors.gameNotFound"));
     }
 
-    const existing = await prisma.character.findFirst({
-      where: {
-        gameId,
-        slug,
-        NOT: { id },
-      },
-    });
-
-    if (existing) {
-      throw new Error(t("character.errors.slugExists"));
-    }
+    await assertSlugAvailable(
+      () => prisma.character.findFirst({ where: { gameId, slug, NOT: { id } } }),
+      t("character.errors.slugExists"),
+    );
 
     const character = await prisma.character.update({
       where: { id },
@@ -73,7 +68,7 @@ export const updateCharacterAction = adminActionClient
         gameId,
         name,
         slug,
-        iconUrl: iconUrl && iconUrl.length > 0 ? iconUrl : null,
+        iconUrl: normalizeOptionalUrl(iconUrl),
       },
     });
 
@@ -85,17 +80,12 @@ export const updateCharacterAction = adminActionClient
 
 export const deleteCharacterAction = adminActionClient
   .inputSchema(
-    z.object({
-      id: z.string().min(1, "admin.validation.character.idRequired"),
-    }),
+    z.object({ id: z.string().min(1, "admin.validation.character.idRequired") }),
   )
-  .action(async ({ parsedInput }) => {
-    await prisma.character.delete({
-      where: { id: parsedInput.id },
-    });
-
-    revalidatePath("/admin/characters");
-    revalidatePath("/admin/games");
-
-    return { success: true };
-  });
+  .action(async ({ parsedInput }) =>
+    runDelete(
+      (id) => prisma.character.delete({ where: { id } }),
+      parsedInput.id,
+      ["/admin/characters", "/admin/games"],
+    ),
+  );

--- a/src/components/features/admin/game/game-action.ts
+++ b/src/components/features/admin/game/game-action.ts
@@ -2,6 +2,11 @@
 
 import { prisma } from "@/lib/prisma";
 import { adminActionClient } from "@/lib/admin-action";
+import {
+  assertSlugAvailable,
+  normalizeOptionalUrl,
+  runDelete,
+} from "@/lib/admin/entity-actions";
 import { revalidatePath } from "next/cache";
 import { getTranslations } from "next-intl/server";
 import { createGameSchema, updateGameSchema } from "./game-schema";
@@ -13,19 +18,16 @@ export const createGameAction = adminActionClient
     const t = await getTranslations("admin");
     const { name, slug, iconUrl } = parsedInput;
 
-    const existing = await prisma.game.findUnique({
-      where: { slug },
-    });
-
-    if (existing) {
-      throw new Error(t("game.errors.slugExists"));
-    }
+    await assertSlugAvailable(
+      () => prisma.game.findUnique({ where: { slug } }),
+      t("game.errors.slugExists"),
+    );
 
     const game = await prisma.game.create({
       data: {
         name,
         slug,
-        iconUrl: iconUrl && iconUrl.length > 0 ? iconUrl : null,
+        iconUrl: normalizeOptionalUrl(iconUrl),
       },
     });
 
@@ -41,23 +43,17 @@ export const updateGameAction = adminActionClient
     const t = await getTranslations("admin");
     const { id, name, slug, iconUrl } = parsedInput;
 
-    const existing = await prisma.game.findFirst({
-      where: {
-        slug,
-        NOT: { id },
-      },
-    });
-
-    if (existing) {
-      throw new Error(t("game.errors.slugExists"));
-    }
+    await assertSlugAvailable(
+      () => prisma.game.findFirst({ where: { slug, NOT: { id } } }),
+      t("game.errors.slugExists"),
+    );
 
     const game = await prisma.game.update({
       where: { id },
       data: {
         name,
         slug,
-        iconUrl: iconUrl && iconUrl.length > 0 ? iconUrl : null,
+        iconUrl: normalizeOptionalUrl(iconUrl),
       },
     });
 
@@ -69,17 +65,11 @@ export const updateGameAction = adminActionClient
 
 export const deleteGameAction = adminActionClient
   .inputSchema(
-    z.object({
-      id: z.string().min(1, "admin.validation.game.idRequired"),
-    }),
+    z.object({ id: z.string().min(1, "admin.validation.game.idRequired") }),
   )
-  .action(async ({ parsedInput }) => {
-    await prisma.game.delete({
-      where: { id: parsedInput.id },
-    });
-
-    revalidatePath("/admin/games");
-    revalidatePath("/characters");
-
-    return { success: true };
-  });
+  .action(async ({ parsedInput }) =>
+    runDelete((id) => prisma.game.delete({ where: { id } }), parsedInput.id, [
+      "/admin/games",
+      "/characters",
+    ]),
+  );

--- a/src/components/features/admin/glossary/article-action.ts
+++ b/src/components/features/admin/glossary/article-action.ts
@@ -2,6 +2,7 @@
 
 import { prisma } from "@/lib/prisma";
 import { adminActionClient } from "@/lib/admin-action";
+import { assertSlugAvailable, runDelete } from "@/lib/admin/entity-actions";
 import { embedGlossaryArticleIfNeeded } from "@/lib/rag/embed-content";
 import { revalidatePath } from "next/cache";
 import { after } from "next/server";
@@ -16,14 +17,10 @@ export const createArticleAction = adminActionClient
     const { title, slug, content, excerpt, category, image, published } =
       parsedInput;
 
-    // Check slug uniqueness
-    const existing = await prisma.glossaryArticle.findUnique({
-      where: { slug },
-    });
-
-    if (existing) {
-      throw new Error(t("article.errors.slugExists"));
-    }
+    await assertSlugAvailable(
+      () => prisma.glossaryArticle.findUnique({ where: { slug } }),
+      t("article.errors.slugExists"),
+    );
 
     const article = await prisma.glossaryArticle.create({
       data: {
@@ -59,17 +56,10 @@ export const updateArticleAction = adminActionClient
     const { id, title, slug, content, excerpt, category, image, published } =
       parsedInput;
 
-    // Check slug uniqueness (excluding current article)
-    const existing = await prisma.glossaryArticle.findFirst({
-      where: {
-        slug,
-        NOT: { id },
-      },
-    });
-
-    if (existing) {
-      throw new Error(t("article.errors.slugExists"));
-    }
+    await assertSlugAvailable(
+      () => prisma.glossaryArticle.findFirst({ where: { slug, NOT: { id } } }),
+      t("article.errors.slugExists"),
+    );
 
     const article = await prisma.glossaryArticle.update({
       where: { id },
@@ -100,17 +90,12 @@ export const updateArticleAction = adminActionClient
 
 export const deleteArticleAction = adminActionClient
   .inputSchema(
-    z.object({
-      id: z.string().min(1, "admin.validation.article.idRequired"),
-    }),
+    z.object({ id: z.string().min(1, "admin.validation.article.idRequired") }),
   )
-  .action(async ({ parsedInput }) => {
-    await prisma.glossaryArticle.delete({
-      where: { id: parsedInput.id },
-    });
-
-    revalidatePath("/glossary");
-    revalidatePath("/admin/glossary");
-
-    return { success: true };
-  });
+  .action(async ({ parsedInput }) =>
+    runDelete(
+      (id) => prisma.glossaryArticle.delete({ where: { id } }),
+      parsedInput.id,
+      ["/glossary", "/admin/glossary"],
+    ),
+  );

--- a/src/lib/admin/entity-actions.ts
+++ b/src/lib/admin/entity-actions.ts
@@ -1,0 +1,49 @@
+import { revalidatePath } from "next/cache";
+
+/**
+ * Shared building blocks for the admin CRUD actions (game / character /
+ * article). Closure-based on purpose: the typed prisma call stays at the call
+ * site, so these helpers stay generic without leaking `any` or coupling to a
+ * specific Prisma delegate. See `.claude/rules/dry.md` for why a single
+ * `makeEntityActions` factory was declined.
+ */
+
+/** `"" | undefined` → `null`, otherwise the trimmed-in URL string. */
+export function normalizeOptionalUrl(
+  value: string | null | undefined,
+): string | null {
+  return value && value.length > 0 ? value : null;
+}
+
+/**
+ * Throw `errorMessage` when `lookup` finds an existing row. Each entity passes
+ * its own scoped query (global, `gameId`-scoped, or `NOT: { id }`).
+ */
+export async function assertSlugAvailable(
+  lookup: () => Promise<unknown | null>,
+  errorMessage: string,
+): Promise<void> {
+  const existing = await lookup();
+  if (existing) {
+    throw new Error(errorMessage);
+  }
+}
+
+/**
+ * Shared body for the `delete` admin actions — the three were ~99% identical.
+ * Kept as a plain async helper (not a factory) because a Next.js `"use server"`
+ * file must export literal async functions, so the action itself stays inline in
+ * each action file; only this body is shared. `deleteById` keeps the typed
+ * prisma delegate at the call site.
+ */
+export async function runDelete(
+  deleteById: (id: string) => Promise<unknown>,
+  id: string,
+  revalidatePaths: string[],
+): Promise<{ success: true }> {
+  await deleteById(id);
+  for (const path of revalidatePaths) {
+    revalidatePath(path);
+  }
+  return { success: true };
+}


### PR DESCRIPTION
## Summary

- New `src/lib/admin/entity-actions.ts` with 3 closure-based helpers: `runDelete`, `assertSlugAvailable`, `normalizeOptionalUrl`
- Dedupe the slug-uniqueness checks, optional-URL normalization and the ~99%-identical delete bodies across game/character/article actions
- Closes the last DRY backlog item in `.claude/rules/dry.md`

## Why no `makeEntityActions` factory

A single generic factory was **declined on purpose**:
- The create/update divergences (character `gameNotFound` pre-check, article `createdBy` + RAG `after()` hook + `image ?? null`, per-entity slug scoping) live in the parts that matter — a config object covering them is longer and less readable than the explicit actions.
- A Prisma-model-generic param has no clean shared delegate type → would force `any` (the codebase has none).
- A `makeDeleteAction` that *returns* the action fails the build: a Next.js `use server` file must export literal async functions. So the delete action stays inline and only its body (`runDelete`) is shared.

The closure helpers remove the real duplication while keeping each action explicit and typed.

## Testing

✓ TypeScript strict  
✓ ESLint clean  
✓ 162 unit tests passing  
✓ Production build (27/27 pages)  
✓ Article RAG `after()` hook preserved

## Type

refactor