### PR TITLE
feat(notation): add charge and double-quarter-circle motions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-06-24
+
+### Added: Charge and double-quarter-circle motions in the notation toolbar (with bracket-aware glyphs)
+
 ## 2026-06-22
 
 ### Refactor: Add a shared Translator type and replace the duplicated MatchTranslator/TemplateTranslator/inline casts (DRY)

--- a/src/components/features/notation/notation-parser.test.ts
+++ b/src/components/features/notation/notation-parser.test.ts
@@ -9,6 +9,11 @@ describe("numpadToGlyphs", () => {
   it("returns null when a digit is not directional (contains 0)", () => {
     expect(numpadToGlyphs("360")).toBeNull();
   });
+
+  it("keeps charge brackets around the directional glyphs", () => {
+    expect(numpadToGlyphs("[4]6")).toBe("[←]→");
+    expect(numpadToGlyphs("[2]8")).toBe("[↓]↑");
+  });
 });
 
 describe("parseNotation", () => {
@@ -105,5 +110,17 @@ describe("parseNotation", () => {
 
   it("does not match a single button letter inside a word", () => {
     expect(parseNotation("Punch")).toEqual([{ kind: "text", raw: "Punch" }]);
+  });
+
+  it("recognizes a charge motion with brackets ([4]6P)", () => {
+    expect(parseNotation("[4]6P")).toEqual([
+      {
+        kind: "motion",
+        raw: "[4]6",
+        glyphs: "[←]→",
+        label: expect.stringContaining("Charge"),
+      },
+      { kind: "button", raw: "P", intensity: "neutral" },
+    ]);
   });
 });

--- a/src/components/features/notation/notation-parser.ts
+++ b/src/components/features/notation/notation-parser.ts
@@ -15,6 +15,10 @@ export const NUMPAD_GLYPHS: Record<string, string> = {
 export function numpadToGlyphs(numpad: string): string | null {
   let glyphs = "";
   for (const char of numpad) {
+    if (char === "[" || char === "]") {
+      glyphs += char;
+      continue;
+    }
     const glyph = NUMPAD_GLYPHS[char];
     if (!glyph) return null;
     glyphs += glyph;
@@ -31,12 +35,16 @@ export type NotationSegment =
   | { kind: "frame"; raw: string; tone: FrameTone }
   | { kind: "text"; raw: string };
 
+function escapeRegex(source: string): string {
+  return source.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
 const FRAME_SOURCE = String.raw`\([+-]\d{1,2}\)|\(0\)`;
 const INTENSITY_BUTTON_SOURCE = `LP|MP|HP|LK|MK|HK`;
 const GENERIC_BUTTON_SOURCE = String.raw`(?:PPP|KKK|PP|KK|P|K)(?![A-Za-z])`;
 const KNOWN_MOTION_SOURCE = [...FGC_MOTIONS]
-  .map((motion) => motion.value)
-  .sort((a, b) => b.length - a.length)
+  .sort((a, b) => b.value.length - a.value.length)
+  .map((motion) => escapeRegex(motion.value))
   .join("|");
 const GENERIC_MOTION_SOURCE = String.raw`[1-9]{2,5}`;
 

--- a/src/components/features/strategy-matrix/strategy-matrix-types.ts
+++ b/src/components/features/strategy-matrix/strategy-matrix-types.ts
@@ -46,6 +46,14 @@ export const FGC_MOTIONS: NotationItem[] = [
   { value: "44", label: "44 (Backdash)" },
   { value: "360", label: "360 (Tour complet / SPD)" },
   { value: "720", label: "720 (Double tour)" },
+  { value: "[4]6", label: "[4]6 (Charge arrière → avant)" },
+  { value: "[2]8", label: "[2]8 (Charge bas → haut)" },
+  { value: "[1]9", label: "[1]9 (Charge bas-arrière → haut-avant)" },
+  { value: "[4]9", label: "[4]9 (Charge arrière → haut-avant)" },
+  { value: "[4]646", label: "[4]646 (Charge super horizontale)" },
+  { value: "[2]828", label: "[2]828 (Charge super verticale)" },
+  { value: "236236", label: "236236 (Double QCF / Super)" },
+  { value: "214214", label: "214214 (Double QCB / Super)" },
 ];
 
 export const FRAME_OPTIONS = [


### PR DESCRIPTION
## Summary

• Add charge motions (`[4]6`, `[2]8`, `[1]9`, `[4]9`) with bracket notation for held direction
• Add charge super combinations (`[4]646`, `[2]828`) 
• Add double-quarter-circle supers (`236236`, `214214`)
• Update notation parser to preserve brackets in glyph rendering
• Add regex escaping for safe motion value matching

## Type

feat