### PR TITLE
feat(editor): add rich markdown editor with formatting toolbar and deploy across forms

### DIFF
--- a/.claude/rules/dry.md
+++ b/.claude/rules/dry.md
@@ -14,6 +14,9 @@ Before duplicating logic, markup or config, reuse the shared building blocks bel
 - **i18n test render**: `renderWithIntl` from `@/test/render-with-intl` — never redeclare the `NextIntlClientProvider` wrapper in a test file.
 - **Translations**: `getTranslations` / `useTranslations` + the `fr` catalogs (see `i18n.md`). Generic labels live in the `common` namespace — reuse, don't duplicate.
 - **Form validation display**: the shadcn `FormMessage` already translates Zod message keys — don't build per-form error rendering.
+- **Rich text input**: `RichMarkdownEditor` from `@/components/features/editor/rich-markdown-editor` — controlled (`value` / `onChange`) markdown editor bundling the format toolbar + `NotationToolbar` + edit/preview toggle + char counter. Drop-in for a bare `<Textarea>` (spread `{...field}` for react-hook-form). Toggle `formatToolbar` / `notationToolbar` / `preview` per surface. Never re-inline a textarea-with-toolbar-and-preview block.
+- **Markdown rendering**: `MarkdownPreview` from `@/components/features/notation/markdown-preview` — the single place wiring `remark-gfm` + `rehypeMark` (`==highlight==`) + `notationComponents`. Don't re-inline `<ReactMarkdown remarkPlugins={…} components={notationComponents}>`.
+- **Textarea selection edits**: `wrapSelection` / `prefixLines` / `replaceSelection` from `@/lib/wrap-selection` (pure, like `insert-notation.ts`) — don't hand-roll cursor slicing in a component.
 
 ## Extract when you see it 3×
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## 2026-06-24
 
+### Added: Shared RichMarkdownEditor with a markdown formatting toolbar (bold, italic, strikethrough, highlight, headings, lists, quote, code block, link)
+
+### Added: Centralized MarkdownPreview wrapper with ==highlight== support via a zero-dependency rehype plugin
+
+### Changed: Note, combo and strategy-matrix forms now use the rich markdown editor (note content capped at 2000 characters)
+
+### Refactor: Memo, strategy-matrix cell and glossary editors converge on the shared RichMarkdownEditor
+
 ### Added: Charge and double-quarter-circle motions in the notation toolbar (with bracket-aware glyphs)
 
 ## 2026-06-22
@@ -18,7 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### Refactor: Extract a shared ConfirmDeleteDialog + useDeleteDialog hook and reuse them across admin, note, combo lists (DRY)
 
-### Refactor: Extract a generic RecentSection component and thin the three dashboard recent-* sections down to config (DRY)
+### Refactor: Extract a generic RecentSection component and thin the three dashboard recent-\* sections down to config (DRY)
 
 ### Refactor: Extract a useActionToast hook and migrate the 16 next-safe-action toast call sites onto it (DRY)
 

--- a/src/components/features/admin/glossary/content-field.tsx
+++ b/src/components/features/admin/glossary/content-field.tsx
@@ -5,9 +5,8 @@ import { useTranslations } from "next-intl";
 import { useRef, useState, type ChangeEvent } from "react";
 import { toast } from "sonner";
 
-import { NotationToolbar } from "@/components/features/notation/notation-toolbar";
+import { RichMarkdownEditor } from "@/components/features/editor/rich-markdown-editor";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { uploadGlossaryImageAction } from "@/lib/actions/upload-glossary-image";
 
 interface ContentFieldProps {
@@ -83,11 +82,6 @@ export function ContentField({ value, onChange }: ContentFieldProps) {
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap items-center gap-2">
-        <NotationToolbar
-          textareaRef={textareaRef}
-          value={value}
-          onValueChange={onChange}
-        />
         <input
           type="file"
           accept="image/jpeg,image/png,image/webp"
@@ -116,11 +110,12 @@ export function ContentField({ value, onChange }: ContentFieldProps) {
         </label>
       </div>
 
-      <Textarea
+      <RichMarkdownEditor
         ref={textareaRef}
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={onChange}
         placeholder={t("article.contentField.placeholder")}
+        ariaLabel={t("article.contentField.placeholder")}
         className="min-h-[300px] font-mono"
       />
     </div>

--- a/src/components/features/admin/glossary/markdown-preview.tsx
+++ b/src/components/features/admin/glossary/markdown-preview.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import rehypeMark from "@/lib/markdown/rehype-mark";
 import { notationComponents } from "@/components/features/notation/notation-renderer";
 
 interface MarkdownPreviewProps {
@@ -17,6 +18,7 @@ export function MarkdownPreview({ content }: MarkdownPreviewProps) {
     <div className="prose prose-invert border-border bg-card text-accent-foreground max-w-none rounded-lg border p-4">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeMark]}
         components={{
           ...notationComponents,
           img: ({ src, alt }) => (

--- a/src/components/features/combo/combo-form.tsx
+++ b/src/components/features/combo/combo-form.tsx
@@ -17,7 +17,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
+import { RichMarkdownEditor } from "@/components/features/editor/rich-markdown-editor";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -248,9 +248,12 @@ export function ComboForm({
             <FormItem>
               <FormLabel>{t("form.notationLabel")}</FormLabel>
               <FormControl>
-                <Textarea
+                <RichMarkdownEditor
                   {...field}
+                  maxLength={500}
+                  formatToolbar={false}
                   placeholder={t("form.notationPlaceholder")}
+                  ariaLabel={t("form.notationLabel")}
                   className="min-h-[100px] font-mono"
                 />
               </FormControl>
@@ -350,10 +353,12 @@ export function ComboForm({
             <FormItem>
               <FormLabel>{t("form.notesLabel")}</FormLabel>
               <FormControl>
-                <Textarea
+                <RichMarkdownEditor
                   {...field}
                   value={field.value ?? ""}
+                  maxLength={2000}
                   placeholder={t("form.notesPlaceholder")}
+                  ariaLabel={t("form.notesLabel")}
                   className="min-h-[80px]"
                 />
               </FormControl>

--- a/src/components/features/editor/format-toolbar.tsx
+++ b/src/components/features/editor/format-toolbar.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useRef, useState, type ReactNode, type RefObject } from "react";
+import {
+  Bold,
+  Code,
+  Heading,
+  Highlighter,
+  Italic,
+  Link as LinkIcon,
+  List,
+  ListOrdered,
+  Quote,
+  Strikethrough,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Separator } from "@/components/ui/separator";
+import {
+  prefixLines,
+  replaceSelection,
+  wrapSelection,
+  type SelectionResult,
+} from "@/lib/wrap-selection";
+
+import { LinkPopover } from "./link-popover";
+
+type Props = {
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  value: string;
+  onValueChange: (next: string) => void;
+  maxLength?: number;
+};
+
+export function FormatToolbar({
+  textareaRef,
+  value,
+  onValueChange,
+  maxLength,
+}: Props) {
+  const t = useTranslations("common.editor");
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [linkText, setLinkText] = useState("");
+  const selectionRef = useRef({ start: 0, end: 0 });
+
+  const getSelection = () => {
+    const textarea = textareaRef.current;
+    return {
+      start: textarea?.selectionStart ?? value.length,
+      end: textarea?.selectionEnd ?? value.length,
+    };
+  };
+
+  const apply = (result: SelectionResult) => {
+    onValueChange(result.value);
+    requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+      textarea?.focus();
+      textarea?.setSelectionRange(result.selectionStart, result.selectionEnd);
+    });
+  };
+
+  const wrap = (before: string, after: string) => {
+    const { start, end } = getSelection();
+    apply(wrapSelection(value, start, end, before, after, { maxLength }));
+  };
+
+  const prefix = (token: string | ((index: number) => string)) => {
+    const { start, end } = getSelection();
+    apply(prefixLines(value, start, end, token, { maxLength }));
+  };
+
+  const openLink = () => {
+    const { start, end } = getSelection();
+    selectionRef.current = { start, end };
+    setLinkText(value.slice(start, end));
+  };
+
+  const insertLink = (text: string, url: string) => {
+    const { start, end } = selectionRef.current;
+    apply(
+      replaceSelection(value, start, end, `[${text}](${url})`, { maxLength }),
+    );
+    setLinkOpen(false);
+  };
+
+  const ToolButton = ({
+    label,
+    onClick,
+    children,
+  }: {
+    label: string;
+    onClick: () => void;
+    children: ReactNode;
+  }) => (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="size-8"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+
+  return (
+    <div
+      role="toolbar"
+      aria-label={t("toolbarLabel")}
+      aria-orientation="horizontal"
+      className="flex flex-wrap items-center gap-0.5"
+    >
+      <ToolButton label={t("bold")} onClick={() => wrap("**", "**")}>
+        <Bold aria-hidden />
+      </ToolButton>
+      <ToolButton label={t("italic")} onClick={() => wrap("_", "_")}>
+        <Italic aria-hidden />
+      </ToolButton>
+      <ToolButton label={t("strikethrough")} onClick={() => wrap("~~", "~~")}>
+        <Strikethrough aria-hidden />
+      </ToolButton>
+      <ToolButton label={t("highlight")} onClick={() => wrap("==", "==")}>
+        <Highlighter aria-hidden />
+      </ToolButton>
+
+      <Separator orientation="vertical" className="mx-1 h-5" />
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-8"
+            aria-label={t("heading")}
+            title={t("heading")}
+          >
+            <Heading aria-hidden />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem onClick={() => prefix("# ")}>
+            {t("heading1")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => prefix("## ")}>
+            {t("heading2")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => prefix("### ")}>
+            {t("heading3")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ToolButton label={t("bulletList")} onClick={() => prefix("- ")}>
+        <List aria-hidden />
+      </ToolButton>
+      <ToolButton
+        label={t("orderedList")}
+        onClick={() => prefix((index) => `${index + 1}. `)}
+      >
+        <ListOrdered aria-hidden />
+      </ToolButton>
+      <ToolButton label={t("quote")} onClick={() => prefix("> ")}>
+        <Quote aria-hidden />
+      </ToolButton>
+      <ToolButton label={t("codeBlock")} onClick={() => wrap("```\n", "\n```")}>
+        <Code aria-hidden />
+      </ToolButton>
+
+      <Separator orientation="vertical" className="mx-1 h-5" />
+
+      <LinkPopover
+        open={linkOpen}
+        onOpenChange={setLinkOpen}
+        initialText={linkText}
+        onSubmit={insertLink}
+        trigger={
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-8"
+            aria-label={t("link")}
+            title={t("link")}
+            onClick={openLink}
+          >
+            <LinkIcon aria-hidden />
+          </Button>
+        }
+      />
+    </div>
+  );
+}

--- a/src/components/features/editor/link-popover.tsx
+++ b/src/components/features/editor/link-popover.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { useTranslations } from "next-intl";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+const urlSchema = z.string().url();
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialText: string;
+  onSubmit: (text: string, url: string) => void;
+  trigger: ReactNode;
+};
+
+export function LinkPopover({
+  open,
+  onOpenChange,
+  initialText,
+  onSubmit,
+  trigger,
+}: Props) {
+  const t = useTranslations("common.editor");
+  const [text, setText] = useState(initialText);
+  const [url, setUrl] = useState("");
+  const [invalid, setInvalid] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setText(initialText);
+      setUrl("");
+      setInvalid(false);
+    }
+  }, [open, initialText]);
+
+  const submit = () => {
+    if (!urlSchema.safeParse(url).success) {
+      setInvalid(true);
+      return;
+    }
+    onSubmit(text.trim() || url, url);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent align="start" className="w-72 space-y-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="rme-link-text" className="text-xs">
+            {t("linkText")}
+          </Label>
+          <Input
+            id="rme-link-text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder={t("linkTextPlaceholder")}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="rme-link-url" className="text-xs">
+            {t("linkUrl")}
+          </Label>
+          <Input
+            id="rme-link-url"
+            type="url"
+            value={url}
+            onChange={(e) => {
+              setUrl(e.target.value);
+              setInvalid(false);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                submit();
+              }
+            }}
+            placeholder="https://…"
+            aria-invalid={invalid}
+          />
+          {invalid && (
+            <p className="text-destructive text-xs">{t("linkUrlInvalid")}</p>
+          )}
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+          >
+            {t("linkCancel")}
+          </Button>
+          <Button type="button" size="sm" onClick={submit}>
+            {t("linkInsert")}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/features/editor/rich-markdown-editor.test.tsx
+++ b/src/components/features/editor/rich-markdown-editor.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { useState } from "react";
+import { fireEvent, screen } from "@testing-library/react";
+
+import { renderWithIntl } from "@/test/render-with-intl";
+import { RichMarkdownEditor } from "./rich-markdown-editor";
+
+function Harness({ initial = "" }: { initial?: string }) {
+  const [value, setValue] = useState(initial);
+  return (
+    <RichMarkdownEditor
+      value={value}
+      onChange={setValue}
+      maxLength={2000}
+      ariaLabel="Note"
+    />
+  );
+}
+
+describe("RichMarkdownEditor", () => {
+  it("renders an accessible formatting toolbar", () => {
+    renderWithIntl(<Harness />);
+    expect(
+      screen.getByRole("toolbar", { name: "Mise en forme du texte" }),
+    ).toBeInTheDocument();
+  });
+
+  it("wraps the current selection when clicking bold", () => {
+    renderWithIntl(<Harness initial="abc" />);
+    const textarea = screen.getByLabelText("Note") as HTMLTextAreaElement;
+    textarea.setSelectionRange(0, 3);
+
+    fireEvent.click(screen.getByRole("button", { name: "Gras" }));
+
+    expect(textarea.value).toBe("**abc**");
+  });
+
+  it("shows the character counter", () => {
+    renderWithIntl(<Harness initial="hello" />);
+    expect(screen.getByText("5 / 2000")).toBeInTheDocument();
+  });
+
+  it("renders markdown in preview mode and hides the textarea", () => {
+    renderWithIntl(<Harness initial="**bold**" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Aperçu" }));
+
+    expect(screen.getByText("bold").tagName).toBe("STRONG");
+    expect(screen.queryByLabelText("Note")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/features/editor/rich-markdown-editor.tsx
+++ b/src/components/features/editor/rich-markdown-editor.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import {
+  forwardRef,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ComponentProps,
+} from "react";
+import { Eye, Pencil } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { MarkdownPreview } from "@/components/features/notation/markdown-preview";
+import { NotationToolbar } from "@/components/features/notation/notation-toolbar";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { wrapSelection } from "@/lib/wrap-selection";
+
+import { FormatToolbar } from "./format-toolbar";
+
+type Props = Omit<ComponentProps<"textarea">, "onChange" | "value" | "ref"> & {
+  value: string;
+  onChange: (next: string) => void;
+  maxLength?: number;
+  ariaLabel?: string;
+  formatToolbar?: boolean;
+  notationToolbar?: boolean;
+  preview?: boolean;
+};
+
+export const RichMarkdownEditor = forwardRef<HTMLTextAreaElement, Props>(
+  function RichMarkdownEditor(
+    {
+      value,
+      onChange,
+      maxLength,
+      ariaLabel,
+      className,
+      formatToolbar = true,
+      notationToolbar = true,
+      preview = true,
+      ...rest
+    },
+    forwardedRef,
+  ) {
+    const t = useTranslations("common.editor");
+    const [showPreview, setShowPreview] = useState(false);
+    const innerRef = useRef<HTMLTextAreaElement>(null);
+
+    const currentValue = value ?? "";
+
+    const setRefs = (node: HTMLTextAreaElement | null) => {
+      innerRef.current = node;
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        forwardedRef.current = node;
+      }
+    };
+
+    const clamp = (next: string) =>
+      maxLength != null ? next.slice(0, maxLength) : next;
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!(event.metaKey || event.ctrlKey)) return;
+      const key = event.key.toLowerCase();
+      if (key !== "b" && key !== "i") return;
+      event.preventDefault();
+
+      const textarea = innerRef.current;
+      const start = textarea?.selectionStart ?? currentValue.length;
+      const end = textarea?.selectionEnd ?? currentValue.length;
+      const marker = key === "b" ? "**" : "_";
+      const result = wrapSelection(currentValue, start, end, marker, marker, {
+        maxLength,
+      });
+
+      onChange(result.value);
+      requestAnimationFrame(() => {
+        textarea?.focus();
+        textarea?.setSelectionRange(result.selectionStart, result.selectionEnd);
+      });
+    };
+
+    return (
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            {!showPreview && formatToolbar && (
+              <FormatToolbar
+                textareaRef={innerRef}
+                value={currentValue}
+                onValueChange={onChange}
+                maxLength={maxLength}
+              />
+            )}
+            {!showPreview && notationToolbar && (
+              <NotationToolbar
+                textareaRef={innerRef}
+                value={currentValue}
+                onValueChange={onChange}
+                maxLength={maxLength}
+              />
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {maxLength != null && (
+              <span className="text-muted-foreground text-xs tabular-nums">
+                {currentValue.length} / {maxLength}
+              </span>
+            )}
+            {preview && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowPreview((v) => !v)}
+                aria-label={showPreview ? t("edit") : t("preview")}
+              >
+                {showPreview ? (
+                  <>
+                    <Pencil className="mr-2 h-3 w-3" aria-hidden />
+                    {t("edit")}
+                  </>
+                ) : (
+                  <>
+                    <Eye className="mr-2 h-3 w-3" aria-hidden />
+                    {t("preview")}
+                  </>
+                )}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {showPreview ? (
+          <MarkdownPreview
+            emptyFallback={t("emptyPreview")}
+            className="border-border bg-muted min-h-[120px] rounded-md border p-3"
+          >
+            {currentValue}
+          </MarkdownPreview>
+        ) : (
+          <Textarea
+            {...rest}
+            ref={setRefs}
+            value={currentValue}
+            onChange={(e) => onChange(clamp(e.target.value))}
+            onKeyDown={handleKeyDown}
+            aria-label={ariaLabel}
+            className={cn("min-h-[120px]", className)}
+          />
+        )}
+      </div>
+    );
+  },
+);

--- a/src/components/features/glossary/glossary-article-detail.tsx
+++ b/src/components/features/glossary/glossary-article-detail.tsx
@@ -6,6 +6,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useTranslations } from "next-intl";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeMark from "@/lib/markdown/rehype-mark";
 import type { ArticleDetail } from "../../../../prisma/query/glossary.query";
 import { formatDate } from "@/utils";
 import { CategoryBadge } from "./glossary-category-badge";
@@ -49,6 +50,7 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
       <div className="max-w-none text-[15px] leading-relaxed">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
+          rehypePlugins={[rehypeMark]}
           components={{
             h1: ({ children }) => (
               <h1 className="mt-8 mb-4 text-2xl font-bold first:mt-0">
@@ -88,6 +90,11 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
               <strong className="text-foreground font-semibold">
                 {children}
               </strong>
+            ),
+            mark: ({ children }) => (
+              <mark className="bg-primary/20 text-foreground rounded-sm px-0.5">
+                {children}
+              </mark>
             ),
             code: ({ className, children }) =>
               className && /language-/.test(className) ? (

--- a/src/components/features/memo/memo-form.tsx
+++ b/src/components/features/memo/memo-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { notationComponents } from "@/components/features/notation/notation-renderer";
-import { NotationToolbar } from "@/components/features/notation/notation-toolbar";
+import { RichMarkdownEditor } from "@/components/features/editor/rich-markdown-editor";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -12,15 +11,10 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Eye, Pencil } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
 import { useForm } from "react-hook-form";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { useActionToast } from "@/hooks/use-action-toast";
 import { createMemoAction, updateMemoAction } from "./memo-action";
 import {
@@ -45,8 +39,6 @@ export function MemoForm(props: Props) {
   const router = useRouter();
   const t = useTranslations("memo.form");
   const tCommon = useTranslations("common.buttons");
-  const [showPreview, setShowPreview] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const form = useForm<MemoFormInput>({
     resolver: zodResolver(memoFormSchema),
@@ -103,65 +95,15 @@ export function MemoForm(props: Props) {
           name="content"
           render={({ field }) => (
             <FormItem>
-              <div className="flex items-center justify-between">
-                <FormLabel>{t("contentLabel")}</FormLabel>
-                <div className="flex items-center gap-2">
-                  <span className="text-muted-foreground text-xs">
-                    {field.value.length} / {MAX_MEMO_CONTENT_LENGTH}
-                  </span>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setShowPreview((v) => !v)}
-                  >
-                    {showPreview ? (
-                      <>
-                        <Pencil className="mr-2 h-3 w-3" />
-                        {t("edit")}
-                      </>
-                    ) : (
-                      <>
-                        <Eye className="mr-2 h-3 w-3" />
-                        {t("preview")}
-                      </>
-                    )}
-                  </Button>
-                </div>
-              </div>
-
-              {!showPreview && (
-                <NotationToolbar
-                  textareaRef={textareaRef}
-                  value={field.value}
-                  onValueChange={(next) => field.onChange(next)}
-                  maxLength={MAX_MEMO_CONTENT_LENGTH}
-                />
-              )}
-
+              <FormLabel>{t("contentLabel")}</FormLabel>
               <FormControl>
-                {showPreview ? (
-                  <div className="prose prose-invert border-border bg-muted text-foreground min-h-[200px] max-w-none rounded-md border p-3 text-sm">
-                    <ReactMarkdown
-                      remarkPlugins={[remarkGfm]}
-                      components={notationComponents}
-                    >
-                      {field.value || t("emptyPreview")}
-                    </ReactMarkdown>
-                  </div>
-                ) : (
-                  <Textarea
-                    ref={textareaRef}
-                    value={field.value}
-                    onChange={(e) =>
-                      field.onChange(
-                        e.target.value.slice(0, MAX_MEMO_CONTENT_LENGTH),
-                      )
-                    }
-                    placeholder={t("contentPlaceholder")}
-                    className="min-h-[240px]"
-                  />
-                )}
+                <RichMarkdownEditor
+                  {...field}
+                  maxLength={MAX_MEMO_CONTENT_LENGTH}
+                  placeholder={t("contentPlaceholder")}
+                  ariaLabel={t("contentLabel")}
+                  className="min-h-[240px]"
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/src/components/features/notation/markdown-preview.tsx
+++ b/src/components/features/notation/markdown-preview.tsx
@@ -1,0 +1,32 @@
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import rehypeMark from "@/lib/markdown/rehype-mark";
+import { cn } from "@/lib/utils";
+
+import { notationComponents } from "./notation-renderer";
+
+type Props = {
+  children: string;
+  className?: string;
+  emptyFallback?: string;
+};
+
+export function MarkdownPreview({ children, className, emptyFallback }: Props) {
+  return (
+    <div
+      className={cn(
+        "prose prose-invert text-foreground max-w-none text-sm",
+        className,
+      )}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeMark]}
+        components={notationComponents}
+      >
+        {children || emptyFallback || ""}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/src/components/features/notation/notation-renderer.tsx
+++ b/src/components/features/notation/notation-renderer.tsx
@@ -40,4 +40,11 @@ export const notationComponents: Partial<Components> = {
 
     return renderInlineNotation(children);
   },
+  mark({ children }) {
+    return (
+      <mark className="bg-primary/20 text-foreground rounded-sm px-0.5">
+        {children}
+      </mark>
+    );
+  },
 };

--- a/src/components/features/strategy-matrix/strategy-matrix-cell-editor.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-cell-editor.tsx
@@ -19,14 +19,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Textarea } from "@/components/ui/textarea";
-import { Eye, Pencil } from "lucide-react";
+import { RichMarkdownEditor } from "@/components/features/editor/rich-markdown-editor";
 import { useTranslations } from "next-intl";
-import { useEffect, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import { notationComponents } from "@/components/features/notation/notation-renderer";
-import { NotationToolbar } from "@/components/features/notation/notation-toolbar";
+import { useEffect, useState } from "react";
 import { FrameLegend } from "./frame-legend";
 import { MAX_CELL_LENGTH } from "./strategy-matrix-types";
 
@@ -50,14 +45,11 @@ export function StrategyMatrixCellEditor({
   const t = useTranslations("strategyMatrix");
   const tc = useTranslations("common");
   const [content, setContent] = useState(initialContent);
-  const [showPreview, setShowPreview] = useState(false);
   const [confirmCloseOpen, setConfirmCloseOpen] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     if (open) {
       setContent(initialContent);
-      setShowPreview(false);
       setConfirmCloseOpen(false);
     }
   }, [open, initialContent]);
@@ -123,65 +115,18 @@ export function StrategyMatrixCellEditor({
               <span className="text-muted-foreground">×</span>
               <span>{opponentLevelLabel}</span>
             </DialogTitle>
-            <DialogDescription>
-              {t("cellEditor.description")}
-            </DialogDescription>
+            <DialogDescription>{t("cellEditor.description")}</DialogDescription>
           </DialogHeader>
 
           <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <span className="text-muted-foreground font-mono text-xs tabular-nums">
-                {content.length} / {MAX_CELL_LENGTH}
-              </span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => setShowPreview((v) => !v)}
-              >
-                {showPreview ? (
-                  <>
-                    <Pencil className="mr-2 h-3 w-3" />
-                    {t("cellEditor.edit")}
-                  </>
-                ) : (
-                  <>
-                    <Eye className="mr-2 h-3 w-3" />
-                    {t("cellEditor.preview")}
-                  </>
-                )}
-              </Button>
-            </div>
-
-            {!showPreview && (
-              <NotationToolbar
-                textareaRef={textareaRef}
-                value={content}
-                onValueChange={setContent}
-                maxLength={MAX_CELL_LENGTH}
-              />
-            )}
-
-            {showPreview ? (
-              <div className="prose prose-invert border-border bg-muted text-foreground min-h-[200px] max-w-none rounded-md border p-3 text-sm">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  components={notationComponents}
-                >
-                  {content || t("cellEditor.emptyPreview")}
-                </ReactMarkdown>
-              </div>
-            ) : (
-              <Textarea
-                ref={textareaRef}
-                value={content}
-                onChange={(e) =>
-                  setContent(e.target.value.slice(0, MAX_CELL_LENGTH))
-                }
-                placeholder={t("cellEditor.placeholder")}
-                className="min-h-[200px]"
-              />
-            )}
+            <RichMarkdownEditor
+              value={content}
+              onChange={setContent}
+              maxLength={MAX_CELL_LENGTH}
+              placeholder={t("cellEditor.placeholder")}
+              ariaLabel={t("cellEditor.eyebrow")}
+              className="min-h-[200px]"
+            />
 
             <FrameLegend className="pt-1" />
           </div>

--- a/src/components/features/strategy-matrix/strategy-matrix-form.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-form.tsx
@@ -10,7 +10,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
+import { RichMarkdownEditor } from "@/components/features/editor/rich-markdown-editor";
 import type { Translator } from "@/types/translator";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTranslations } from "next-intl";
@@ -110,9 +110,7 @@ export function StrategyMatrixForm(props: Props) {
   const router = useRouter();
   const t = useTranslations("strategyMatrix");
   const tc = useTranslations("common");
-  const templates = resolveStrategyMatrixTemplates(
-    t as unknown as Translator,
-  );
+  const templates = resolveStrategyMatrixTemplates(t as unknown as Translator);
   const fallback = props.initialTemplate ?? templates[0];
   const initialValues: StrategyMatrixCreateInput =
     props.mode === "edit"
@@ -313,10 +311,12 @@ export function StrategyMatrixForm(props: Props) {
                 <FormItem>
                   <FormLabel>{t("form.descriptionLabel")}</FormLabel>
                   <FormControl>
-                    <Textarea
+                    <RichMarkdownEditor
                       placeholder={t("form.descriptionPlaceholder")}
+                      ariaLabel={t("form.descriptionLabel")}
                       value={field.value ?? ""}
                       onChange={field.onChange}
+                      maxLength={500}
                       className="min-h-[60px]"
                     />
                   </FormControl>

--- a/src/components/features/strategy-matrix/strategy-matrix-grid.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-grid.tsx
@@ -2,9 +2,7 @@
 
 import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import { notationComponents } from "@/components/features/notation/notation-renderer";
+import { MarkdownPreview } from "@/components/features/notation/markdown-preview";
 import type { Axis, Cell } from "./strategy-matrix-schema";
 import { buildCellLookup, cellKey } from "./strategy-matrix-types";
 
@@ -87,14 +85,9 @@ export function StrategyMatrixGrid({
                       t("grid.emptyCell")
                     )
                   ) : (
-                    <div className="prose prose-invert prose-sm line-clamp-5 max-w-none [&_*]:my-0 [&_li]:leading-snug [&_p]:leading-snug">
-                      <ReactMarkdown
-                        remarkPlugins={[remarkGfm]}
-                        components={notationComponents}
-                      >
-                        {content}
-                      </ReactMarkdown>
-                    </div>
+                    <MarkdownPreview className="prose-sm line-clamp-5 [&_*]:my-0 [&_li]:leading-snug [&_p]:leading-snug">
+                      {content}
+                    </MarkdownPreview>
                   )}
                 </div>
               );

--- a/src/components/features/video/note-form.tsx
+++ b/src/components/features/video/note-form.tsx
@@ -11,7 +11,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Textarea } from "@/components/ui/textarea";
+import { RichMarkdownEditor } from "@/components/features/editor/rich-markdown-editor";
 import { useSpeechRecognition } from "@/hooks/use-speech-recognition";
 import { useVideoPlayerStore } from "@/stores/video-player";
 import { formatTime } from "@/utils";
@@ -23,7 +23,11 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { createNoteAction } from "./note-action";
-import { noteSchema, NoteSchemaType } from "./note-schema";
+import {
+  MAX_NOTE_CONTENT_LENGTH,
+  noteSchema,
+  NoteSchemaType,
+} from "./note-schema";
 import { NoteSuggestTagsButton } from "./note-suggest-tags-button";
 import { NoteTagButton } from "./note-tag-button";
 import { NoteTemplateSelector } from "./note-template-selector";
@@ -90,7 +94,10 @@ export function NoteForm({ matchId, availableTags }: NoteFormProps) {
 
   useEffect(() => {
     if (transcript) {
-      form.setValue("note", transcript, { shouldDirty: true, shouldValidate: true });
+      form.setValue("note", transcript, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
     }
   }, [transcript, form]);
 
@@ -173,7 +180,7 @@ export function NoteForm({ matchId, availableTags }: NoteFormProps) {
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <FormLabel>{t("label")}</FormLabel>
-                  <span className="bg-accent text-primary rounded font-mono text-xs font-bold tabular-nums px-2 py-0.5">
+                  <span className="bg-accent text-primary rounded px-2 py-0.5 font-mono text-xs font-bold tabular-nums">
                     {formatTime(currentTime)}
                   </span>
                 </div>
@@ -188,9 +195,11 @@ export function NoteForm({ matchId, availableTags }: NoteFormProps) {
                 </div>
               </div>
               <FormControl>
-                <Textarea
+                <RichMarkdownEditor
                   {...field}
+                  maxLength={MAX_NOTE_CONTENT_LENGTH}
                   placeholder={t("placeholder")}
+                  ariaLabel={t("label")}
                   className="min-h-[100px]"
                 />
               </FormControl>
@@ -207,7 +216,9 @@ export function NoteForm({ matchId, availableTags }: NoteFormProps) {
 
         <div className="space-y-3">
           <div className="flex items-center justify-between">
-            <FormLabel>{t("tagsLabel", { count: selectedTagIds.length })}</FormLabel>
+            <FormLabel>
+              {t("tagsLabel", { count: selectedTagIds.length })}
+            </FormLabel>
             <NoteSuggestTagsButton
               onSuggest={handleSuggestTags}
               isSuggesting={isSuggesting}

--- a/src/components/features/video/note-schema.ts
+++ b/src/components/features/video/note-schema.ts
@@ -1,7 +1,12 @@
 import z from "zod";
 
+export const MAX_NOTE_CONTENT_LENGTH = 2000;
+
 export const noteSchema = z.object({
-  note: z.string().min(2, { error: "video.validation.noteMin" }),
+  note: z
+    .string()
+    .min(2, { error: "video.validation.noteMin" })
+    .max(MAX_NOTE_CONTENT_LENGTH, { error: "video.validation.noteMax" }),
   tagIds: z
     .array(z.string())
     .min(1, { error: "video.validation.tagRequired" })

--- a/src/lib/markdown/rehype-mark.test.ts
+++ b/src/lib/markdown/rehype-mark.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import rehypeMark from "./rehype-mark";
+
+type HastNode = {
+  type: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+};
+
+function paragraph(...children: HastNode[]): HastNode {
+  return {
+    type: "root",
+    children: [{ type: "element", tagName: "p", properties: {}, children }],
+  };
+}
+
+function run(tree: HastNode): HastNode {
+  rehypeMark()(tree);
+  return tree;
+}
+
+describe("rehypeMark", () => {
+  it("turns ==text== into a <mark> element", () => {
+    const tree = run(paragraph({ type: "text", value: "a ==b== c" }));
+    const children = tree.children![0].children!;
+    expect(children).toEqual([
+      { type: "text", value: "a " },
+      {
+        type: "element",
+        tagName: "mark",
+        properties: {},
+        children: [{ type: "text", value: "b" }],
+      },
+      { type: "text", value: " c" },
+    ]);
+  });
+
+  it("handles multiple highlights in one text node", () => {
+    const tree = run(paragraph({ type: "text", value: "==x== and ==y==" }));
+    const marks = tree.children![0].children!.filter(
+      (n) => n.tagName === "mark",
+    );
+    expect(marks).toHaveLength(2);
+  });
+
+  it("leaves plain text untouched", () => {
+    const tree = run(paragraph({ type: "text", value: "no markers here" }));
+    expect(tree.children![0].children).toEqual([
+      { type: "text", value: "no markers here" },
+    ]);
+  });
+
+  it("does not transform inside code or pre", () => {
+    const tree = run({
+      type: "root",
+      children: [
+        {
+          type: "element",
+          tagName: "code",
+          properties: {},
+          children: [{ type: "text", value: "==x==" }],
+        },
+      ],
+    });
+    expect(tree.children![0].children).toEqual([
+      { type: "text", value: "==x==" },
+    ]);
+  });
+});

--- a/src/lib/markdown/rehype-mark.ts
+++ b/src/lib/markdown/rehype-mark.ts
@@ -1,0 +1,69 @@
+type HastNode = {
+  type: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+};
+
+const MARK_PATTERN = /==(.+?)==/g;
+const SKIP_TAGS = new Set(["code", "pre"]);
+
+function splitTextNode(node: HastNode): HastNode[] | null {
+  const value = node.value ?? "";
+  if (!value.includes("==")) return null;
+
+  MARK_PATTERN.lastIndex = 0;
+  const segments: HastNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = MARK_PATTERN.exec(value)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({
+        type: "text",
+        value: value.slice(lastIndex, match.index),
+      });
+    }
+    segments.push({
+      type: "element",
+      tagName: "mark",
+      properties: {},
+      children: [{ type: "text", value: match[1] }],
+    });
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (segments.length === 0) return null;
+  if (lastIndex < value.length) {
+    segments.push({ type: "text", value: value.slice(lastIndex) });
+  }
+
+  return segments;
+}
+
+function transform(node: HastNode): void {
+  if (!node.children) return;
+  if (node.tagName && SKIP_TAGS.has(node.tagName)) return;
+
+  const next: HastNode[] = [];
+  for (const child of node.children) {
+    if (child.type === "text") {
+      const split = splitTextNode(child);
+      if (split) {
+        next.push(...split);
+        continue;
+      }
+    } else {
+      transform(child);
+    }
+    next.push(child);
+  }
+  node.children = next;
+}
+
+export default function rehypeMark() {
+  return (tree: HastNode) => {
+    transform(tree);
+  };
+}

--- a/src/lib/wrap-selection.test.ts
+++ b/src/lib/wrap-selection.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { prefixLines, replaceSelection, wrapSelection } from "./wrap-selection";
+
+describe("wrapSelection", () => {
+  it("wraps the current selection with the markers", () => {
+    expect(wrapSelection("abc", 0, 3, "**", "**")).toEqual({
+      value: "**abc**",
+      selectionStart: 2,
+      selectionEnd: 5,
+    });
+  });
+
+  it("inserts empty markers and places the cursor between them when nothing is selected", () => {
+    expect(wrapSelection("", 0, 0, "**", "**")).toEqual({
+      value: "****",
+      selectionStart: 2,
+      selectionEnd: 2,
+    });
+  });
+
+  it("wraps only the selected slice in the middle of the text", () => {
+    expect(wrapSelection("a word here", 2, 6, "_", "_")).toEqual({
+      value: "a _word_ here",
+      selectionStart: 3,
+      selectionEnd: 7,
+    });
+  });
+
+  it("clamps the result to maxLength", () => {
+    const { value } = wrapSelection("abcdef", 0, 6, "**", "**", {
+      maxLength: 8,
+    });
+    expect(value.length).toBe(8);
+  });
+});
+
+describe("replaceSelection", () => {
+  it("replaces the selection and puts the cursor after the replacement", () => {
+    expect(replaceSelection("see here", 4, 8, "[here](https://x.io)")).toEqual({
+      value: "see [here](https://x.io)",
+      selectionStart: 24,
+      selectionEnd: 24,
+    });
+  });
+});
+
+describe("prefixLines", () => {
+  it("prefixes a single line", () => {
+    expect(prefixLines("title", 0, 0, "# ")).toEqual({
+      value: "# title",
+      selectionStart: 0,
+      selectionEnd: 7,
+    });
+  });
+
+  it("prefixes every line covered by the selection", () => {
+    expect(prefixLines("a\nb\nc", 0, 5, "- ")).toEqual({
+      value: "- a\n- b\n- c",
+      selectionStart: 0,
+      selectionEnd: 11,
+    });
+  });
+
+  it("supports an index-based prefix for ordered lists", () => {
+    expect(prefixLines("a\nb", 0, 3, (index) => `${index + 1}. `)).toEqual({
+      value: "1. a\n2. b",
+      selectionStart: 0,
+      selectionEnd: 9,
+    });
+  });
+
+  it("only prefixes the line the cursor sits on", () => {
+    expect(prefixLines("first\nsecond", 7, 7, "> ")).toEqual({
+      value: "first\n> second",
+      selectionStart: 6,
+      selectionEnd: 14,
+    });
+  });
+});

--- a/src/lib/wrap-selection.ts
+++ b/src/lib/wrap-selection.ts
@@ -1,0 +1,93 @@
+type SelectionOptions = {
+  maxLength?: number;
+};
+
+export type SelectionResult = {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+};
+
+function clampSelection(
+  value: string,
+  start: number,
+  end: number,
+): SelectionResult {
+  const length = value.length;
+  return {
+    value,
+    selectionStart: Math.min(start, length),
+    selectionEnd: Math.min(end, length),
+  };
+}
+
+export function wrapSelection(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  before: string,
+  after: string,
+  options: SelectionOptions = {},
+): SelectionResult {
+  const head = value.slice(0, selectionStart);
+  const selected = value.slice(selectionStart, selectionEnd);
+  const tail = value.slice(selectionEnd);
+
+  const nextValue = (head + before + selected + after + tail).slice(
+    0,
+    options.maxLength,
+  );
+
+  return clampSelection(
+    nextValue,
+    selectionStart + before.length,
+    selectionStart + before.length + selected.length,
+  );
+}
+
+export function replaceSelection(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  replacement: string,
+  options: SelectionOptions = {},
+): SelectionResult {
+  const head = value.slice(0, selectionStart);
+  const tail = value.slice(selectionEnd);
+
+  const nextValue = (head + replacement + tail).slice(0, options.maxLength);
+
+  return clampSelection(
+    nextValue,
+    selectionStart + replacement.length,
+    selectionStart + replacement.length,
+  );
+}
+
+export function prefixLines(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  prefix: string | ((index: number) => string),
+  options: SelectionOptions = {},
+): SelectionResult {
+  const lineStart = value.lastIndexOf("\n", selectionStart - 1) + 1;
+  const newlineAfter = value.indexOf("\n", selectionEnd);
+  const lineEnd = newlineAfter === -1 ? value.length : newlineAfter;
+
+  const head = value.slice(0, lineStart);
+  const block = value.slice(lineStart, lineEnd);
+  const tail = value.slice(lineEnd);
+
+  const resolvePrefix = (index: number) =>
+    typeof prefix === "function" ? prefix(index) : prefix;
+
+  const nextBlock = block
+    .split("\n")
+    .map((line, index) => `${resolvePrefix(index)}${line}`)
+    .join("\n");
+
+  const nextValue = (head + nextBlock + tail).slice(0, options.maxLength);
+
+  return clampSelection(nextValue, lineStart, lineStart + nextBlock.length);
+}

--- a/src/messages/fr/common.json
+++ b/src/messages/fr/common.json
@@ -20,5 +20,30 @@
     "required": "Ce champ est requis",
     "maxChars": "Maximum {count} caractères",
     "minChars": "Minimum {count} caractères"
+  },
+  "editor": {
+    "toolbarLabel": "Mise en forme du texte",
+    "bold": "Gras",
+    "italic": "Italique",
+    "strikethrough": "Barré",
+    "highlight": "Surligné",
+    "heading": "Titre",
+    "heading1": "Titre 1",
+    "heading2": "Titre 2",
+    "heading3": "Titre 3",
+    "bulletList": "Liste à puces",
+    "orderedList": "Liste numérotée",
+    "quote": "Citation",
+    "codeBlock": "Bloc de code",
+    "link": "Lien",
+    "linkText": "Texte du lien",
+    "linkTextPlaceholder": "Texte affiché",
+    "linkUrl": "URL",
+    "linkUrlInvalid": "URL invalide",
+    "linkInsert": "Insérer",
+    "linkCancel": "Annuler",
+    "preview": "Aperçu",
+    "edit": "Édition",
+    "emptyPreview": "*Aucun contenu*"
   }
 }

--- a/src/messages/fr/video.json
+++ b/src/messages/fr/video.json
@@ -74,6 +74,7 @@
   },
   "validation": {
     "noteMin": "La note doit contenir au moins 2 caractères",
+    "noteMax": "La note ne peut pas dépasser 2000 caractères",
     "tagRequired": "Au moins un tag doit être sélectionné",
     "tagMax": "Maximum 10 tags autorisés",
     "noteIdRequired": "L'ID de la note est requis"


### PR DESCRIPTION
## Summary

• New `RichMarkdownEditor` component with markdown formatting toolbar (bold, italic, strikethrough, highlight, headings, lists, quote, code block, link)
• Centralized `<MarkdownPreview>` wrapper with rehypeMark plugin for `==highlight==` support
• Pure helpers `wrapSelection` / `prefixLines` / `replaceSelection` for textarea selection manipulation (modeled on `insert-notation.ts`)
• Deploy on Note form (content capped at 2000 chars for RAG), combo notes/notation, and strategy-matrix description
• Convergence: memo form, strategy-matrix cell editor, and glossary content field migrate to shared editor (net −168 lines of duplication)
• Strategy-matrix grid and glossary views gain centralized markdown rendering with `==highlight==` support
• i18n: new `common.editor` namespace and `video.validation.noteMax` key
• DRY rule: register new shared building blocks

## Type

feat