### PR TITLE
feat(notation): add cascading button submenus for positions and motions

### DIFF
--- a/.claude/rules/dry.md
+++ b/.claude/rules/dry.md
@@ -18,6 +18,19 @@ Before duplicating logic, markup or config, reuse the shared building blocks bel
 - **Markdown rendering**: `MarkdownPreview` from `@/components/features/notation/markdown-preview` — the single place wiring `remark-gfm` + `rehypeMark` (`==highlight==`) + `notationComponents`. Don't re-inline `<ReactMarkdown remarkPlugins={…} components={notationComponents}>`.
 - **Textarea selection edits**: `wrapSelection` / `prefixLines` / `replaceSelection` from `@/lib/wrap-selection` (pure, like `insert-notation.ts`) — don't hand-roll cursor slicing in a component.
 
+## Don't over-DRY — avoid premature abstraction
+
+DRY is about a single source of truth for **knowledge**, not about deleting every visual or syntactic similarity. Wrong abstractions cost more than duplication: they couple unrelated callers, sprout boolean/config flags, and are painful to unwind. Prefer a little duplication over the wrong abstraction.
+
+**Do NOT extract when:**
+
+- The pattern appears only **2×** and isn't error-prone — wait for the third (rule of three). Two similar blocks side by side are fine and often clearer.
+- The similarity is **coincidental** (the blocks look alike today but answer to different reasons and will drift apart). Duplication that evolves independently is not a DRY violation.
+- Collapsing them forces a parametrized component/function whose body is mostly `if (variant)` branches or `renderX` props — that's a sign the cases aren't really the same thing.
+- The shared helper would need to know about its callers' specifics (leaky params, context flags) to behave correctly.
+
+**When unsure**: leave the duplication, and add a short note (or a backlog entry below) at the spot so the third occurrence triggers the extraction with full context. Don't abstract on a guess.
+
 ## Extract when you see it 3×
 
 - A confirmation dialog → reuse `ConfirmDeleteDialog`, not an inline `AlertDialog` per list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-06-26
+
+### Added: Cascading button submenu on notation positions to insert combined tokens like st.LP in one click
+
+### Added: Cascading button submenu on notation motions to insert combined tokens like 236LP in one click
+
 ## 2026-06-24
 
 ### Added: Shared RichMarkdownEditor with a markdown formatting toolbar (bold, italic, strikethrough, highlight, headings, lists, quote, code block, link)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added: Cascading button submenu on notation motions to insert combined tokens like 236LP in one click
 
+### Docs: Add anti-premature-abstraction guidance to the DRY rule
+
 ## 2026-06-24
 
 ### Added: Shared RichMarkdownEditor with a markdown formatting toolbar (bold, italic, strikethrough, highlight, headings, lists, quote, code block, link)

--- a/src/components/features/notation/notation-toolbar.tsx
+++ b/src/components/features/notation/notation-toolbar.tsx
@@ -7,16 +7,27 @@ import {
   FGC_POSITIONS,
   FRAME_OPTIONS,
 } from "@/components/features/strategy-matrix/strategy-matrix-types";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Select,
   SelectContent,
-  SelectGroup,
   SelectItem,
-  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
 import { insertNotationToken } from "@/lib/insert-notation";
+import { ChevronDown } from "lucide-react";
 import { useState, type RefObject } from "react";
 import { numpadToGlyphs } from "./notation-parser";
 
@@ -33,8 +44,6 @@ export function NotationToolbar({
   onValueChange,
   maxLength,
 }: Props) {
-  const [notationKey, setNotationKey] = useState(0);
-  const [motionKey, setMotionKey] = useState(0);
   const [frameKey, setFrameKey] = useState(0);
 
   const handleInsert = (
@@ -59,69 +68,118 @@ export function NotationToolbar({
     });
   };
 
+  const insertButton = (token: string) =>
+    handleInsert(token, { closeZone: true });
+
   return (
     <div className="flex items-center gap-2">
-      <Select
-        key={`notation-${notationKey}`}
-        onValueChange={(v) => {
-          handleInsert(v, {
-            closeZone: FGC_BUTTONS.some((button) => button.value === v),
-          });
-          setNotationKey((k) => k + 1);
-        }}
-      >
-        <SelectTrigger size="sm" className="w-auto text-xs">
-          <SelectValue placeholder="Notation..." />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectGroup>
-            <SelectLabel>Positions</SelectLabel>
-            {FGC_POSITIONS.map((item) => (
-              <SelectItem key={item.value} value={item.value}>
-                {item.label}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Boutons</SelectLabel>
-            {FGC_BUTTONS.map((item) => (
-              <SelectItem key={item.value} value={item.value}>
-                {item.label}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel>Actions</SelectLabel>
-            {FGC_ACTIONS.map((item) => (
-              <SelectItem key={item.value} value={item.value}>
-                {item.label}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-        </SelectContent>
-      </Select>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-auto gap-1.5 px-3 text-xs font-normal text-muted-foreground"
+          >
+            Notation...
+            <ChevronDown aria-hidden className="size-4 opacity-50" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuLabel>Positions</DropdownMenuLabel>
+          {FGC_POSITIONS.map((position) => (
+            <DropdownMenuSub key={position.value}>
+              <DropdownMenuSubTrigger>{position.label}</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem
+                  onSelect={() => handleInsert(position.value)}
+                  className="font-mono"
+                >
+                  {position.value}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                {FGC_BUTTONS.map((button) => (
+                  <DropdownMenuItem
+                    key={button.value}
+                    onSelect={() => insertButton(position.value + button.value)}
+                    className="font-mono"
+                  >
+                    {position.value}
+                    {button.value}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          ))}
 
-      <Select
-        key={`motion-${motionKey}`}
-        onValueChange={(v) => {
-          handleInsert(v);
-          setMotionKey((k) => k + 1);
-        }}
-      >
-        <SelectTrigger size="sm" className="w-auto text-xs">
-          <SelectValue placeholder="Motion..." />
-        </SelectTrigger>
-        <SelectContent>
-          {FGC_MOTIONS.map((item) => {
-            const glyphs = numpadToGlyphs(item.value);
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel>Boutons</DropdownMenuLabel>
+          {FGC_BUTTONS.map((button) => (
+            <DropdownMenuItem
+              key={button.value}
+              onSelect={() => insertButton(button.value)}
+            >
+              {button.label}
+            </DropdownMenuItem>
+          ))}
+
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+          {FGC_ACTIONS.map((action) => (
+            <DropdownMenuItem
+              key={action.value}
+              onSelect={() => handleInsert(action.value)}
+            >
+              {action.label}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-auto gap-1.5 px-3 text-xs font-normal text-muted-foreground"
+          >
+            Motion...
+            <ChevronDown aria-hidden className="size-4 opacity-50" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          {FGC_MOTIONS.map((motion) => {
+            const glyphs = numpadToGlyphs(motion.value);
             return (
-              <SelectItem key={item.value} value={item.value}>
-                {glyphs ? `${glyphs}  ${item.label}` : item.label}
-              </SelectItem>
+              <DropdownMenuSub key={motion.value}>
+                <DropdownMenuSubTrigger>
+                  {glyphs ? `${glyphs}  ${motion.label}` : motion.label}
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  <DropdownMenuItem
+                    onSelect={() => handleInsert(motion.value)}
+                    className="font-mono"
+                  >
+                    {glyphs ? `${glyphs} ${motion.value}` : motion.value}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  {FGC_BUTTONS.map((button) => (
+                    <DropdownMenuItem
+                      key={button.value}
+                      onSelect={() => insertButton(motion.value + button.value)}
+                      className="font-mono"
+                    >
+                      {motion.value}
+                      {button.value}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
             );
           })}
-        </SelectContent>
-      </Select>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       <Select
         key={`frame-${frameKey}`}


### PR DESCRIPTION
## Summary

• Converted notation Positions and Motions selects to DropdownMenus with cascading button submenus
• Hovering a position or motion now displays available attack buttons; picking one inserts the combined token (e.g. `st.LP`, `236LP`) in one click
• Position/motion alone remains insertable as the first submenu item
• Standalone Boutons and Actions groups preserved

## Type

feat