### PR TITLE
feat(editor): add undo/redo with keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## 2026-06-26
 
+### Added: Undo/redo arrows in the rich markdown editor with Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z shortcuts
+
 ### Added: Cascading button submenu on notation positions to insert combined tokens like st.LP in one click
 
 ### Added: Cascading button submenu on notation motions to insert combined tokens like 236LP in one click

--- a/src/components/features/editor/rich-markdown-editor.tsx
+++ b/src/components/features/editor/rich-markdown-editor.tsx
@@ -7,17 +7,19 @@ import {
   type KeyboardEvent,
   type ComponentProps,
 } from "react";
-import { Eye, Pencil } from "lucide-react";
+import { Eye, Pencil, Redo2, Undo2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { MarkdownPreview } from "@/components/features/notation/markdown-preview";
 import { NotationToolbar } from "@/components/features/notation/notation-toolbar";
 import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { wrapSelection } from "@/lib/wrap-selection";
 
 import { FormatToolbar } from "./format-toolbar";
+import { useEditorHistory } from "./use-editor-history";
 
 type Props = Omit<ComponentProps<"textarea">, "onChange" | "value" | "ref"> & {
   value: string;
@@ -49,6 +51,7 @@ export const RichMarkdownEditor = forwardRef<HTMLTextAreaElement, Props>(
     const innerRef = useRef<HTMLTextAreaElement>(null);
 
     const currentValue = value ?? "";
+    const history = useEditorHistory(currentValue, onChange);
 
     const setRefs = (node: HTMLTextAreaElement | null) => {
       innerRef.current = node;
@@ -65,6 +68,21 @@ export const RichMarkdownEditor = forwardRef<HTMLTextAreaElement, Props>(
     const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
       if (!(event.metaKey || event.ctrlKey)) return;
       const key = event.key.toLowerCase();
+
+      if (key === "z") {
+        event.preventDefault();
+        if (event.shiftKey) {
+          history.redo();
+        } else {
+          history.undo();
+        }
+        return;
+      }
+      if (key === "y") {
+        event.preventDefault();
+        history.redo();
+        return;
+      }
       if (key !== "b" && key !== "i") return;
       event.preventDefault();
 
@@ -76,7 +94,7 @@ export const RichMarkdownEditor = forwardRef<HTMLTextAreaElement, Props>(
         maxLength,
       });
 
-      onChange(result.value);
+      history.record(result.value);
       requestAnimationFrame(() => {
         textarea?.focus();
         textarea?.setSelectionRange(result.selectionStart, result.selectionEnd);
@@ -87,11 +105,40 @@ export const RichMarkdownEditor = forwardRef<HTMLTextAreaElement, Props>(
       <div className="space-y-2">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <div className="flex flex-wrap items-center gap-2">
+            {!showPreview && (
+              <div className="flex items-center gap-0.5">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-8"
+                  aria-label={t("undo")}
+                  title={t("undo")}
+                  disabled={!history.canUndo}
+                  onClick={history.undo}
+                >
+                  <Undo2 aria-hidden />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-8"
+                  aria-label={t("redo")}
+                  title={t("redo")}
+                  disabled={!history.canRedo}
+                  onClick={history.redo}
+                >
+                  <Redo2 aria-hidden />
+                </Button>
+                <Separator orientation="vertical" className="mx-1 h-5" />
+              </div>
+            )}
             {!showPreview && formatToolbar && (
               <FormatToolbar
                 textareaRef={innerRef}
                 value={currentValue}
-                onValueChange={onChange}
+                onValueChange={history.record}
                 maxLength={maxLength}
               />
             )}
@@ -99,7 +146,7 @@ export const RichMarkdownEditor = forwardRef<HTMLTextAreaElement, Props>(
               <NotationToolbar
                 textareaRef={innerRef}
                 value={currentValue}
-                onValueChange={onChange}
+                onValueChange={history.record}
                 maxLength={maxLength}
               />
             )}
@@ -146,7 +193,7 @@ export const RichMarkdownEditor = forwardRef<HTMLTextAreaElement, Props>(
             {...rest}
             ref={setRefs}
             value={currentValue}
-            onChange={(e) => onChange(clamp(e.target.value))}
+            onChange={(e) => history.record(clamp(e.target.value))}
             onKeyDown={handleKeyDown}
             aria-label={ariaLabel}
             className={cn("min-h-[120px]", className)}

--- a/src/components/features/editor/use-editor-history.ts
+++ b/src/components/features/editor/use-editor-history.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const COALESCE_MS = 400;
+
+type EditorHistory = {
+  record: (next: string) => void;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+};
+
+export function useEditorHistory(
+  value: string,
+  onChange: (next: string) => void,
+): EditorHistory {
+  const stackRef = useRef<string[]>([value]);
+  const indexRef = useRef(0);
+  const lastEditAtRef = useRef(0);
+  const skipSyncRef = useRef(false);
+  const [, rerender] = useState(0);
+  const refresh = () => rerender((n) => n + 1);
+
+  useEffect(() => {
+    if (skipSyncRef.current) {
+      skipSyncRef.current = false;
+      return;
+    }
+    if (value === stackRef.current[indexRef.current]) return;
+
+    stackRef.current = [
+      ...stackRef.current.slice(0, indexRef.current + 1),
+      value,
+    ];
+    indexRef.current = stackRef.current.length - 1;
+    lastEditAtRef.current = 0;
+    refresh();
+  }, [value]);
+
+  const record = useCallback(
+    (next: string) => {
+      const now = Date.now();
+      const coalesce = now - lastEditAtRef.current < COALESCE_MS;
+      lastEditAtRef.current = now;
+      skipSyncRef.current = true;
+
+      if (coalesce) {
+        stackRef.current[indexRef.current] = next;
+      } else {
+        stackRef.current = [
+          ...stackRef.current.slice(0, indexRef.current + 1),
+          next,
+        ];
+        indexRef.current = stackRef.current.length - 1;
+      }
+
+      onChange(next);
+      refresh();
+    },
+    [onChange],
+  );
+
+  const undo = useCallback(() => {
+    if (indexRef.current === 0) return;
+    indexRef.current -= 1;
+    lastEditAtRef.current = 0;
+    skipSyncRef.current = true;
+    onChange(stackRef.current[indexRef.current]);
+    refresh();
+  }, [onChange]);
+
+  const redo = useCallback(() => {
+    if (indexRef.current >= stackRef.current.length - 1) return;
+    indexRef.current += 1;
+    lastEditAtRef.current = 0;
+    skipSyncRef.current = true;
+    onChange(stackRef.current[indexRef.current]);
+    refresh();
+  }, [onChange]);
+
+  return {
+    record,
+    undo,
+    redo,
+    canUndo: indexRef.current > 0,
+    canRedo: indexRef.current < stackRef.current.length - 1,
+  };
+}

--- a/src/messages/fr/common.json
+++ b/src/messages/fr/common.json
@@ -42,6 +42,8 @@
     "linkUrlInvalid": "URL invalide",
     "linkInsert": "Insérer",
     "linkCancel": "Annuler",
+    "undo": "Annuler",
+    "redo": "Rétablir",
     "preview": "Aperçu",
     "edit": "Édition",
     "emptyPreview": "*Aucun contenu*"


### PR DESCRIPTION
## Summary

• Add undo/redo history to RichMarkdownEditor with smart coalescing
• Support Ctrl/Cmd+Z, Ctrl/Cmd+Shift+Z, and Ctrl/Cmd+Y shortcuts
• Add undo/redo arrow buttons in the formatting toolbar (disabled when unavailable)
• Wire all edits (textarea, toolbar, keyboard shortcuts) through history
• Localize button labels and tooltips to French

## Changes

- `src/components/features/editor/use-editor-history.ts` — new hook managing edit history stack with 400ms keystroke coalescing and external sync
- `src/components/features/editor/rich-markdown-editor.tsx` — integrate history hook, add undo/redo buttons, wire keyboard shortcuts, use `history.record()` for all mutations
- `src/messages/fr/common.json` — add `undo` and `redo` keys
- `CHANGELOG.md` — document feature

## Testing

✓ TypeScript type check
✓ ESLint lint
✓ Existing editor tests pass (4/4)