### PR TITLE
feat(visualize): navigate lists with arrow keys and side buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## 2026-06-27
 
+### Added: Navigate between memos and strategy matrices inside the visualize dialog with side arrows and arrow keys
+
 ### Changed: Space memo visualize dialog paragraphs on double line breaks like the glossary (drop remark-breaks)
 
 ## 2026-06-26

--- a/src/components/features/memo/memo-list.tsx
+++ b/src/components/features/memo/memo-list.tsx
@@ -18,10 +18,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { FolderOpen, Trash2 } from "lucide-react";
+import { Eye, FolderOpen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { useActionToast } from "@/hooks/use-action-toast";
 import { formatDate } from "@/utils";
 import type { MemoListItem } from "../../../../prisma/query/memo.query";
@@ -35,7 +36,9 @@ type Props = {
 export function MemoList({ memos }: Props) {
   const router = useRouter();
   const t = useTranslations("memo.list");
+  const tViz = useTranslations("memo.visualize");
   const tCommon = useTranslations("common.buttons");
+  const [visualizeIndex, setVisualizeIndex] = useState<number | null>(null);
   const { execute, isPending } = useActionToast(deleteMemoAction, {
     successMessage: t("deleted"),
     errorMessage: t("deleteError"),
@@ -56,66 +59,88 @@ export function MemoList({ memos }: Props) {
   }
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {memos.map((memo) => (
-        <Card key={memo.id} className="flex flex-col gap-3 p-4">
-          <div className="space-y-1">
-            <h3 className="line-clamp-1 font-semibold">{memo.title}</h3>
-            {memo.content && (
-              <p className="text-muted-foreground line-clamp-3 text-sm whitespace-pre-wrap">
-                {memo.content}
-              </p>
-            )}
-          </div>
-          <div className="text-muted-foreground text-xs">
-            {t("updatedOn")} {formatDate(memo.updatedAt)}
-          </div>
-          <div className="mt-auto flex justify-end gap-2">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button asChild size="icon" variant="outline">
-                  <Link href={`/notes/memo/${memo.id}`} aria-label={t("open")}>
-                    <FolderOpen className="h-4 w-4" />
-                  </Link>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{t("open")}</TooltipContent>
-            </Tooltip>
-            <MemoVisualizeDialog title={memo.title} content={memo.content} />
-            <AlertDialog>
+    <>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {memos.map((memo, index) => (
+          <Card key={memo.id} className="flex flex-col gap-3 p-4">
+            <div className="space-y-1">
+              <h3 className="line-clamp-1 font-semibold">{memo.title}</h3>
+              {memo.content && (
+                <p className="text-muted-foreground line-clamp-3 text-sm whitespace-pre-wrap">
+                  {memo.content}
+                </p>
+              )}
+            </div>
+            <div className="text-muted-foreground text-xs">
+              {t("updatedOn")} {formatDate(memo.updatedAt)}
+            </div>
+            <div className="mt-auto flex justify-end gap-2">
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      disabled={isPending}
-                      aria-label={t("delete")}
+                  <Button asChild size="icon" variant="outline">
+                    <Link
+                      href={`/notes/memo/${memo.id}`}
+                      aria-label={t("open")}
                     >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </AlertDialogTrigger>
+                      <FolderOpen className="h-4 w-4" />
+                    </Link>
+                  </Button>
                 </TooltipTrigger>
-                <TooltipContent>{t("delete")}</TooltipContent>
+                <TooltipContent>{t("open")}</TooltipContent>
               </Tooltip>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>{t("deleteTitle")}</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    {t("deleteDescription", { title: memo.title })}
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>{tCommon("cancel")}</AlertDialogCancel>
-                  <AlertDialogAction onClick={() => execute({ id: memo.id })}>
-                    {tCommon("delete")}
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </div>
-        </Card>
-      ))}
-    </div>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    aria-label={tViz("trigger")}
+                    onClick={() => setVisualizeIndex(index)}
+                  >
+                    <Eye className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{tViz("trigger")}</TooltipContent>
+              </Tooltip>
+              <AlertDialog>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        disabled={isPending}
+                        aria-label={t("delete")}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </AlertDialogTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>{t("delete")}</TooltipContent>
+                </Tooltip>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>{t("deleteTitle")}</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {t("deleteDescription", { title: memo.title })}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>{tCommon("cancel")}</AlertDialogCancel>
+                    <AlertDialogAction onClick={() => execute({ id: memo.id })}>
+                      {tCommon("delete")}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
+          </Card>
+        ))}
+      </div>
+      <MemoVisualizeDialog
+        memos={memos}
+        index={visualizeIndex}
+        onIndexChange={setVisualizeIndex}
+      />
+    </>
   );
 }

--- a/src/components/features/memo/memo-visualize-dialog.tsx
+++ b/src/components/features/memo/memo-visualize-dialog.tsx
@@ -7,54 +7,95 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { Eye } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useCallback, useEffect } from "react";
 
-type Props = {
+type VisualizeMemo = {
+  id: string;
   title: string;
   content: string;
 };
 
-export function MemoVisualizeDialog({ title, content }: Props) {
+type Props = {
+  memos: VisualizeMemo[];
+  index: number | null;
+  onIndexChange: (index: number | null) => void;
+};
+
+export function MemoVisualizeDialog({ memos, index, onIndexChange }: Props) {
   const t = useTranslations("memo");
-  const [open, setOpen] = useState(false);
+  const memo = index != null ? memos[index] : null;
+  const hasMultiple = memos.length > 1;
+
+  const goPrev = useCallback(() => {
+    onIndexChange(
+      index == null ? null : (index - 1 + memos.length) % memos.length,
+    );
+  }, [index, memos.length, onIndexChange]);
+
+  const goNext = useCallback(() => {
+    onIndexChange(index == null ? null : (index + 1) % memos.length);
+  }, [index, memos.length, onIndexChange]);
+
+  useEffect(() => {
+    if (index == null || !hasMultiple) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "ArrowLeft") goPrev();
+      if (event.key === "ArrowRight") goNext();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [index, hasMultiple, goPrev, goNext]);
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DialogTrigger asChild>
-            <Button
-              variant="outline"
-              size="icon"
-              aria-label={t("visualize.trigger")}
-            >
-              <Eye className="h-4 w-4" />
-            </Button>
-          </DialogTrigger>
-        </TooltipTrigger>
-        <TooltipContent>{t("visualize.trigger")}</TooltipContent>
-      </Tooltip>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[700px]">
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
-        </DialogHeader>
-        {content ? (
-          <MarkdownPreview className="space-y-4 leading-relaxed [&_ol]:list-decimal [&_ol]:pl-6 [&_ul]:list-disc [&_ul]:pl-6 [&_li]:leading-relaxed">
-            {content}
-          </MarkdownPreview>
-        ) : (
-          <p className="text-muted-foreground text-sm">
-            {t("visualize.emptyContent")}
-          </p>
+    <Dialog
+      open={index != null}
+      onOpenChange={(isOpen) => !isOpen && onIndexChange(null)}
+    >
+      <DialogContent className="max-h-[90vh] sm:max-w-[700px]">
+        {memo && (
+          <>
+            <DialogHeader>
+              <DialogTitle>{memo.title}</DialogTitle>
+            </DialogHeader>
+            <div className="max-h-[75vh] overflow-y-auto px-1">
+              {memo.content ? (
+                <MarkdownPreview className="space-y-4 leading-relaxed [&_ol]:list-decimal [&_ol]:pl-6 [&_ul]:list-disc [&_ul]:pl-6 [&_li]:leading-relaxed">
+                  {memo.content}
+                </MarkdownPreview>
+              ) : (
+                <p className="text-muted-foreground text-sm">
+                  {t("visualize.emptyContent")}
+                </p>
+              )}
+            </div>
+            {hasMultiple && (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label={t("visualize.previous")}
+                  onClick={goPrev}
+                  className="absolute top-1/2 -left-16 z-10 size-11 -translate-y-1/2 rounded-full shadow-md"
+                >
+                  <ChevronLeft className="h-5 w-5" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label={t("visualize.next")}
+                  onClick={goNext}
+                  className="absolute top-1/2 -right-16 z-10 size-11 -translate-y-1/2 rounded-full shadow-md"
+                >
+                  <ChevronRight className="h-5 w-5" />
+                </Button>
+              </>
+            )}
+          </>
         )}
       </DialogContent>
     </Dialog>

--- a/src/components/features/strategy-matrix/strategy-matrix-list.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-list.tsx
@@ -18,10 +18,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { FolderOpen, Trash2 } from "lucide-react";
+import { Eye, FolderOpen, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { useActionToast } from "@/hooks/use-action-toast";
 import { StrategyMatrixVisualizeDialog } from "./strategy-matrix-visualize-dialog";
 import { axisSchema } from "./strategy-matrix-schema";
@@ -41,6 +42,7 @@ export function StrategyMatrixList({ matrices }: Props) {
   const router = useRouter();
   const t = useTranslations("strategyMatrix");
   const tc = useTranslations("common");
+  const [visualizeIndex, setVisualizeIndex] = useState<number | null>(null);
   const { execute, isPending } = useActionToast(deleteStrategyMatrixAction, {
     successMessage: t("list.toast.deleted"),
     errorMessage: t("list.toast.deleteError"),
@@ -61,98 +63,116 @@ export function StrategyMatrixList({ matrices }: Props) {
   }
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {matrices.map((matrix) => {
-        const matchupBadges = [
-          matrix.game?.name,
-          matrix.myCharacter?.name,
-          matrix.opponentCharacter?.name &&
-            `vs ${matrix.opponentCharacter.name}`,
-        ].filter(Boolean) as string[];
+    <>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {matrices.map((matrix, index) => {
+          const matchupBadges = [
+            matrix.game?.name,
+            matrix.myCharacter?.name,
+            matrix.opponentCharacter?.name &&
+              `vs ${matrix.opponentCharacter.name}`,
+          ].filter(Boolean) as string[];
 
-        return (
-          <Card key={matrix.id} className="flex flex-col gap-3 p-4">
-            <div className="space-y-1">
-              <h3 className="line-clamp-1 font-semibold">{matrix.title}</h3>
-              {matchupBadges.length > 0 && (
-                <div className="flex flex-wrap gap-1">
-                  {matchupBadges.map((label) => (
-                    <span
-                      key={label}
-                      className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-[10px]"
-                    >
-                      {label}
-                    </span>
-                  ))}
-                </div>
-              )}
-              {matrix.description && (
-                <p className="text-muted-foreground line-clamp-2 text-sm">
-                  {matrix.description}
-                </p>
-              )}
-            </div>
-            <div className="text-muted-foreground text-xs">
-              {safeAxisLabel(matrix.myAxis)} ×{" "}
-              {safeAxisLabel(matrix.opponentAxis)}
-            </div>
-            <div className="mt-auto flex justify-end gap-2">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button asChild size="icon" variant="outline">
-                    <Link
-                      href={`/notes/strategy/${matrix.id}`}
-                      aria-label={t("list.open")}
-                    >
-                      <FolderOpen className="h-4 w-4" />
-                    </Link>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>{t("list.open")}</TooltipContent>
-              </Tooltip>
-              <StrategyMatrixVisualizeDialog
-                title={matrix.title}
-                myAxis={matrix.myAxis}
-                opponentAxis={matrix.opponentAxis}
-                cells={matrix.cells}
-              />
-              <AlertDialog>
+          return (
+            <Card key={matrix.id} className="flex flex-col gap-3 p-4">
+              <div className="space-y-1">
+                <h3 className="line-clamp-1 font-semibold">{matrix.title}</h3>
+                {matchupBadges.length > 0 && (
+                  <div className="flex flex-wrap gap-1">
+                    {matchupBadges.map((label) => (
+                      <span
+                        key={label}
+                        className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-[10px]"
+                      >
+                        {label}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {matrix.description && (
+                  <p className="text-muted-foreground line-clamp-2 text-sm">
+                    {matrix.description}
+                  </p>
+                )}
+              </div>
+              <div className="text-muted-foreground text-xs">
+                {safeAxisLabel(matrix.myAxis)} ×{" "}
+                {safeAxisLabel(matrix.opponentAxis)}
+              </div>
+              <div className="mt-auto flex justify-end gap-2">
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <AlertDialogTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="icon"
-                        disabled={isPending}
-                        aria-label={tc("buttons.delete")}
+                    <Button asChild size="icon" variant="outline">
+                      <Link
+                        href={`/notes/strategy/${matrix.id}`}
+                        aria-label={t("list.open")}
                       >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </AlertDialogTrigger>
+                        <FolderOpen className="h-4 w-4" />
+                      </Link>
+                    </Button>
                   </TooltipTrigger>
-                  <TooltipContent>{tc("buttons.delete")}</TooltipContent>
+                  <TooltipContent>{t("list.open")}</TooltipContent>
                 </Tooltip>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>{t("list.deleteTitle")}</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      {t("list.deleteDescription", { title: matrix.title })}
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>{tc("buttons.cancel")}</AlertDialogCancel>
-                    <AlertDialogAction
-                      onClick={() => execute({ id: matrix.id })}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      aria-label={t("visualize.trigger")}
+                      onClick={() => setVisualizeIndex(index)}
                     >
-                      {tc("buttons.delete")}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            </div>
-          </Card>
-        );
-      })}
-    </div>
+                      <Eye className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t("visualize.trigger")}</TooltipContent>
+                </Tooltip>
+                <AlertDialog>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <AlertDialogTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          disabled={isPending}
+                          aria-label={tc("buttons.delete")}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </AlertDialogTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>{tc("buttons.delete")}</TooltipContent>
+                  </Tooltip>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        {t("list.deleteTitle")}
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        {t("list.deleteDescription", { title: matrix.title })}
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>
+                        {tc("buttons.cancel")}
+                      </AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => execute({ id: matrix.id })}
+                      >
+                        {tc("buttons.delete")}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+      <StrategyMatrixVisualizeDialog
+        matrices={matrices}
+        index={visualizeIndex}
+        onIndexChange={setVisualizeIndex}
+      />
+    </>
   );
 }

--- a/src/components/features/strategy-matrix/strategy-matrix-visualize-dialog.tsx
+++ b/src/components/features/strategy-matrix/strategy-matrix-visualize-dialog.tsx
@@ -6,75 +6,116 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { Eye } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import z from "zod";
 import { StrategyMatrixGrid } from "./strategy-matrix-grid";
 import { axisSchema, cellSchema } from "./strategy-matrix-schema";
 
-type Props = {
+type VisualizeMatrix = {
+  id: string;
   title: string;
   myAxis: unknown;
   opponentAxis: unknown;
   cells: unknown;
 };
 
+type Props = {
+  matrices: VisualizeMatrix[];
+  index: number | null;
+  onIndexChange: (index: number | null) => void;
+};
+
 export function StrategyMatrixVisualizeDialog({
-  title,
-  myAxis,
-  opponentAxis,
-  cells,
+  matrices,
+  index,
+  onIndexChange,
 }: Props) {
   const t = useTranslations("strategyMatrix");
-  const [open, setOpen] = useState(false);
+  const matrix = index != null ? matrices[index] : null;
+  const hasMultiple = matrices.length > 1;
 
   const parsed = useMemo(() => {
-    const my = axisSchema.safeParse(myAxis);
-    const opp = axisSchema.safeParse(opponentAxis);
-    const c = z.array(cellSchema).safeParse(cells);
+    if (!matrix) return null;
+    const my = axisSchema.safeParse(matrix.myAxis);
+    const opp = axisSchema.safeParse(matrix.opponentAxis);
+    const c = z.array(cellSchema).safeParse(matrix.cells);
     if (!my.success || !opp.success || !c.success) return null;
     return { myAxis: my.data, opponentAxis: opp.data, cells: c.data };
-  }, [myAxis, opponentAxis, cells]);
+  }, [matrix]);
+
+  const goPrev = useCallback(() => {
+    onIndexChange(
+      index == null ? null : (index - 1 + matrices.length) % matrices.length,
+    );
+  }, [index, matrices.length, onIndexChange]);
+
+  const goNext = useCallback(() => {
+    onIndexChange(index == null ? null : (index + 1) % matrices.length);
+  }, [index, matrices.length, onIndexChange]);
+
+  useEffect(() => {
+    if (index == null || !hasMultiple) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "ArrowLeft") goPrev();
+      if (event.key === "ArrowRight") goNext();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [index, hasMultiple, goPrev, goNext]);
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DialogTrigger asChild>
-            <Button
-              variant="outline"
-              size="icon"
-              aria-label={t("visualize.trigger")}
-            >
-              <Eye className="h-4 w-4" />
-            </Button>
-          </DialogTrigger>
-        </TooltipTrigger>
-        <TooltipContent>{t("visualize.trigger")}</TooltipContent>
-      </Tooltip>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[90vw]">
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
-        </DialogHeader>
-        {parsed ? (
-          <StrategyMatrixGrid
-            myAxis={parsed.myAxis}
-            opponentAxis={parsed.opponentAxis}
-            cells={parsed.cells}
-            readOnly
-          />
-        ) : (
-          <p className="text-muted-foreground text-sm">
-            {t("visualize.error")}
-          </p>
+    <Dialog
+      open={index != null}
+      onOpenChange={(isOpen) => !isOpen && onIndexChange(null)}
+    >
+      <DialogContent className="max-h-[90vh] sm:max-w-[85vw]">
+        {matrix && (
+          <>
+            <DialogHeader>
+              <DialogTitle>{matrix.title}</DialogTitle>
+            </DialogHeader>
+            <div className="max-h-[75vh] overflow-auto px-1">
+              {parsed ? (
+                <StrategyMatrixGrid
+                  myAxis={parsed.myAxis}
+                  opponentAxis={parsed.opponentAxis}
+                  cells={parsed.cells}
+                  readOnly
+                />
+              ) : (
+                <p className="text-muted-foreground text-sm">
+                  {t("visualize.error")}
+                </p>
+              )}
+            </div>
+            {hasMultiple && (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label={t("visualize.previous")}
+                  onClick={goPrev}
+                  className="absolute top-1/2 -left-16 z-10 size-11 -translate-y-1/2 rounded-full shadow-md"
+                >
+                  <ChevronLeft className="h-5 w-5" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label={t("visualize.next")}
+                  onClick={goNext}
+                  className="absolute top-1/2 -right-16 z-10 size-11 -translate-y-1/2 rounded-full shadow-md"
+                >
+                  <ChevronRight className="h-5 w-5" />
+                </Button>
+              </>
+            )}
+          </>
         )}
       </DialogContent>
     </Dialog>

--- a/src/messages/fr/memo.json
+++ b/src/messages/fr/memo.json
@@ -36,7 +36,9 @@
   },
   "visualize": {
     "trigger": "Visualiser",
-    "emptyContent": "Aucun contenu."
+    "emptyContent": "Aucun contenu.",
+    "previous": "Mémo précédent",
+    "next": "Mémo suivant"
   },
   "errors": {
     "notFound": "Mémo introuvable",

--- a/src/messages/fr/strategy-matrix.json
+++ b/src/messages/fr/strategy-matrix.json
@@ -142,7 +142,9 @@
   },
   "visualize": {
     "trigger": "Visualiser",
-    "error": "Impossible d'afficher cette matrice."
+    "error": "Impossible d'afficher cette matrice.",
+    "previous": "Matrice précédente",
+    "next": "Matrice suivante"
   },
   "frameLegend": {
     "heading": "Frame data",


### PR DESCRIPTION
## Summary

• Navigate through memos and strategy matrices inside visualize dialogs without closing
• Left/right arrow keys + side arrow buttons (↖/↗) for list navigation
• Circular wrap-around navigation
• Arrow buttons hidden when only one item in list
• French translations for previous/next actions

## Changes

- Lifted visualize state from single-dialog components to list components (controlled `index`)
- Updated `MemoVisualizeDialog` and `StrategyMatrixVisualizeDialog` to accept array + index
- Eye buttons on each card now trigger dialog at specific index
- Added keyboard listeners (ArrowLeft/ArrowRight) with 14-item offset for accessibility
- Added French i18n keys in `memo.json` and `strategy-matrix.json`

## Testing

- Navigate between items using side arrows
- Navigate using keyboard (← →)
- Verify single-item lists don't show nav arrows
- Close dialog and reopen at different index