### PR TITLE
feat(editor): space preview paragraphs on double line breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## 2026-06-27
 
+### Changed: Space rich markdown editor preview paragraphs on double line breaks like the visualize dialog
+
 ### Added: Navigate between memos and strategy matrices inside the visualize dialog with side arrows and arrow keys
 
 ### Changed: Space memo visualize dialog paragraphs on double line breaks like the glossary (drop remark-breaks)

--- a/src/components/features/editor/rich-markdown-editor.tsx
+++ b/src/components/features/editor/rich-markdown-editor.tsx
@@ -184,7 +184,7 @@ export const RichMarkdownEditor = forwardRef<HTMLTextAreaElement, Props>(
         {showPreview ? (
           <MarkdownPreview
             emptyFallback={t("emptyPreview")}
-            className="border-border bg-muted min-h-[120px] rounded-md border p-3"
+            className="border-border bg-muted min-h-[120px] space-y-4 rounded-md border p-3 leading-relaxed [&_li]:leading-relaxed [&_ol]:list-decimal [&_ol]:pl-6 [&_ul]:list-disc [&_ul]:pl-6"
           >
             {currentValue}
           </MarkdownPreview>


### PR DESCRIPTION
## Summary

• Rich markdown editor preview now renders paragraph breaks consistently with the memo visualize dialog
• Added `space-y-4 leading-relaxed` and list styling to preview className to match final render

## Type

feat(editor)